### PR TITLE
Remove unused import

### DIFF
--- a/texthero/visualization.py
+++ b/texthero/visualization.py
@@ -6,7 +6,6 @@ import pandas as pd
 import plotly.express as px
 
 from wordcloud import WordCloud
-from nltk import NLTKWordTokenizer
 
 from texthero import preprocessing
 import string


### PR DESCRIPTION
The line `from nltk import NLTKWordTokenizer` in `visualization.py` causes import issues. I think it should probably be `from nltk.tokenize import word_tokenize`, but at present the import is not used in the file at all, so we can just remove it for simplicity's sake.