### PR TITLE
Use ==/!= to compare constant literals (str, bytes, int, float, tuple)

### DIFF
--- a/texthero/preprocessing.py
+++ b/texthero/preprocessing.py
@@ -329,9 +329,9 @@ def stem(input: pd.Series, stem="snowball", language="english") -> pd.Series:
     dtype: object
     """
 
-    if stem is "porter":
+    if stem == "porter":
         stemmer = PorterStemmer()
-    elif stem is "snowball":
+    elif stem == "snowball":
         stemmer = SnowballStemmer(language)
     else:
         raise ValueError("stem argument must be either 'porter' of 'stemmer'")


### PR DESCRIPTION
Avoid [SyntaxWarnings on Python >= 3.8](https://docs.python.org/3/whatsnew/3.8.html#porting-to-python-3-8).

% `python3.8`
```
>>> "snowball" is "snowball"
<stdin>:1: SyntaxWarning: "is" with a literal. Did you mean "=="?
```