### PR TITLE
Preprocessing removed the capturing group from regex

### DIFF
--- a/texthero/preprocessing.py
+++ b/texthero/preprocessing.py
@@ -709,7 +709,7 @@ def replace_tags(s: pd.Series, symbol: str) -> pd.Series:
 
     """
 
-    pattern = r"@([a-zA-Z0-9]+)"
+    pattern = r"@[a-zA-Z0-9]+"
     return s.str.replace(pattern, symbol)
 
 


### PR DESCRIPTION
We removed the capturing brackets from tags. The initial commit had no issues. Just for more clarity and adhering to convention.