### PR TITLE
Improve remove_diacritics function. Fixes #71

### DIFF
--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -90,8 +90,8 @@ class TestPreprocessing(PandasTestCase):
     """
 
     def test_remove_diactitics(self):
-        s = pd.Series("hèllo")
-        s_true = pd.Series("hello")
+        s = pd.Series("Montréal, über, 12.89, Mère, Françoise, noël, 889, اِس, اُس")
+        s_true = pd.Series("Montreal, uber, 12.89, Mere, Francoise, noel, 889, اس, اس")
         self.assertEqual(preprocessing.remove_diacritics(s), s_true)
 
     """


### PR DESCRIPTION
The remove_diacritics function produced transliterated output for e.g.
the Urdu alphabet.

Through the unicodedata package, diacritics are now safely filtered out.