### PR TITLE
Make Text-Based Representation functions take tokenized input. Closes #44

### DIFF
--- a/tests/test_indexes.py
+++ b/tests/test_indexes.py
@@ -55,8 +55,12 @@ test_cases_preprocessing = [
 ]
 
 test_cases_representation = [
-    ["term_frequency", representation.term_frequency, (s_text,)],
-    ["tfidf", representation.tfidf, (s_text,)],
+    [
+        "term_frequency",
+        representation.term_frequency,
+        (preprocessing.tokenize(s_text),),
+    ],
+    ["tfidf", representation.tfidf, (preprocessing.tokenize(s_text),)],
     ["pca", representation.pca, (s_numeric_lists, 0)],
     ["nmf", representation.nmf, (s_numeric_lists,)],
     ["tsne", representation.tsne, (s_numeric_lists,)],

--- a/tests/test_representation.py
+++ b/tests/test_representation.py
@@ -25,22 +25,31 @@ class TestRepresentation(PandasTestCase):
 
     def test_term_frequency_single_document(self):
         s = pd.Series("a b c c")
+        s = preprocessing.tokenize(s)
         s_true = pd.Series([[1, 1, 2]])
         self.assertEqual(representation.term_frequency(s), s_true)
 
     def test_term_frequency_multiple_documents(self):
         s = pd.Series(["doc_one", "doc_two"])
-        s_true = pd.Series([[1, 0], [0, 1]])
+        s = preprocessing.tokenize(s)
+        s_true = pd.Series([[1, 1, 1, 0], [1, 1, 0, 1]])
         self.assertEqual(representation.term_frequency(s), s_true)
 
     def test_term_frequency_not_lowercase(self):
         s = pd.Series(["one ONE"])
+        s = preprocessing.tokenize(s)
         s_true = pd.Series([[1, 1]])
         self.assertEqual(representation.term_frequency(s), s_true)
 
     def test_term_frequency_punctuation_are_kept(self):
         s = pd.Series(["one !"])
+        s = preprocessing.tokenize(s)
         s_true = pd.Series([[1, 1]])
+        self.assertEqual(representation.term_frequency(s), s_true)
+
+    def test_term_frequency_not_tokenized_yet(self):
+        s = pd.Series("a b c c")
+        s_true = pd.Series([[1, 1, 2]])
         self.assertEqual(representation.term_frequency(s), s_true)
 
     """
@@ -49,6 +58,12 @@ class TestRepresentation(PandasTestCase):
 
     def test_idf_single_document(self):
         s = pd.Series("a")
+        s = preprocessing.tokenize(s)
+        s_true = pd.Series([[1]])
+        self.assertEqual(representation.tfidf(s), s_true)
+
+    def test_idf_not_tokenized_yet(self):
+        s = pd.Series("a")
         s_true = pd.Series([[1]])
         self.assertEqual(representation.tfidf(s), s_true)
 
@@ -56,6 +71,7 @@ class TestRepresentation(PandasTestCase):
         tfidf_single_smooth = 0.7071067811865475  # TODO
 
         s = pd.Series("ONE one")
+        s = preprocessing.tokenize(s)
         s_true = pd.Series([[tfidf_single_smooth, tfidf_single_smooth]])
         self.assertEqual(representation.tfidf(s), s_true)
 
@@ -71,6 +87,19 @@ class TestRepresentation(PandasTestCase):
         )
 
         s = preprocessing.tokenize(s)
+
+        df_embedding = representation.word2vec(s, min_count=1, seed=1)
+
+        self.assertEqual(type(df_embedding), pd.DataFrame)
+
+        self.assertEqual(df_embedding.shape, df_true.shape)
+
+    def test_word2vec_not_tokenized_yet(self):
+        s = pd.Series(["today is a beautiful day", "today is not that beautiful"])
+        df_true = pd.DataFrame(
+            [[0.0] * 300] * 7,
+            index=["a", "beautiful", "day", "is", "not", "that", "today"],
+        )
 
         df_embedding = representation.word2vec(s, min_count=1, seed=1)
 

--- a/texthero/representation.py
+++ b/texthero/representation.py
@@ -24,7 +24,7 @@ from texthero import preprocessing
 
 # Warning message for not-tokenized inputs
 _not_tokenized_warning_message = (
-    "🤔 It seems like the given Pandas Series s is not tokenized. This function will"
+    "It seems like the given Pandas Series s is not tokenized. This function will"
     " tokenize it automatically using hero.tokenize(s) first. You should consider"
     " tokenizing it yourself first with hero.tokenize(s) in the future."
 )

--- a/texthero/representation.py
+++ b/texthero/representation.py
@@ -86,7 +86,6 @@ def term_frequency(
     tf = CountVectorizer(
         max_features=max_features,
         lowercase=False,
-        token_pattern="\S+",
         tokenizer=lambda x: x,
         preprocessor=lambda x: x,
     )
@@ -150,7 +149,6 @@ def tfidf(s: pd.Series, max_features=None, min_df=1, return_feature_names=False)
         use_idf=True,
         max_features=max_features,
         min_df=min_df,
-        token_pattern="\S+",
         lowercase=False,
         tokenizer=lambda x: x,
         preprocessor=lambda x: x,


### PR DESCRIPTION
Now checks for all text-based functions in representation.py whether the
input is already tokenized. If not,
it prints a warning and tokenizes.

Docstrings and tests are changed accordingly.