### PR TITLE
Update Docstrings in Visualization Module

### DIFF
--- a/texthero/visualization.py
+++ b/texthero/visualization.py
@@ -25,13 +25,46 @@ def scatterplot(
     return_figure=False,
 ):
     """
-    Show scatterplot using python plotly scatter.
+    Show scatterplot of DataFrame column using python plotly scatter.
+
 
     Parameters
     ----------
-    df
-    col
-        The name of the column of the DataFrame used for x and y axis.
+    df: DataFrame with a column to be visualized.
+
+    col: str
+        The name of the column of the DataFrame to use for x and y axis.
+
+    color: str, default to None.
+        Name of the column to use for coloring (rows with same value get same color).
+
+    title: str, default to "".
+        Title of the plot.
+
+    return_figure: optional, default to False.
+        Function returns the figure if set to True.
+
+    hover_data: List[str], default to [].
+        List of column names to supply data when hovering over a point.
+
+    hover_name: str, default to None
+        Name of the column to supply title of hover data when hovering over a point.
+
+    Examples
+    --------
+    >>> import texthero as hero
+    >>> import pandas as pd
+    >>> doc1 = "Football, Sports, Soccer"
+    >>> doc2 = "music, violin, orchestra"
+    >>> doc3 = "football, fun, sports"
+    >>> doc4 = "music, fun, guitar"
+    >>> df = pd.DataFrame([doc1, doc2, doc3, doc4], columns=["texts"])
+    >>> df["texts"] = hero.clean(df["texts"])
+    >>> df["texts"] = hero.tokenize(df["texts"])
+    >>> df["tfidf"] = hero.tfidf(df["texts"])
+    >>> df["topics"] = hero.kmeans(df["tfidf"], n_clusters=2)
+    >>> df["pca"] = hero.pca(df["tfidf"], n_components=3)
+    >>> hero.scatterplot(df, col="pca", color="topics", hover_name="texts") # doctest: +SKIP
     """
 
     pca0 = df[col].apply(lambda x: x[0])
@@ -78,26 +111,42 @@ def wordcloud(
     Parameters
     ----------
     s : pd.Series
+
     font_path : str
-        Font path to the font that will be used (OTF or TTF). Defaults to DroidSansMono path on a Linux machine. If you are on another OS or don't have this font, you need to adjust this path.
+        Font path to the font that will be used (OTF or TTF).
+        Defaults to DroidSansMono path on a Linux machine.
+        If you are on another OS or don't have this font, you need to adjust this path.
+
     width : int
         Width of the canvas.
+
     height : int
         Height of the canvas.
+
     max_words : number (default=200)
         The maximum number of words.
+
     mask : nd-array or None (default=None)
-        When set, gives a binary mask on where to draw words. When set, width and height will be ignored and the shape of mask will be used instead. All white (#FF or #FFFFFF) entries will be considerd "masked out" while other entries will be free to draw on.
+        When set, gives a binary mask on where to draw words.
+        When set, width and height will be ignored and the shape of mask will be used instead.
+        All white (#FF or #FFFFFF) entries will be considerd "masked out" while other
+        entries will be free to draw on.
+
     contour_width: float (default=0)
         If mask is not None and contour_width > 0, draw the mask contour.
+
     contour_color: color value (default="PAPAYAWHIP")
         Mask contour color.
+
     min_font_size : int (default=4)
         Smallest font size to use. Will stop when there is no more room in this size.
+
     background_color : color value (default="PAPAYAWHIP")
         Background color for the word cloud image.
+
     max_font_size : int or None (default=None)
         Maximum font size for the largest word. If None, height of the image is used.
+
     relative_scaling : float (default='auto')
         Importance of relative word frequencies for font-size.  With
         relative_scaling=0, only word-ranks are considered.  With
@@ -106,8 +155,10 @@ def wordcloud(
         their rank, relative_scaling around .5 often looks good.
         If 'auto' it will be set to 0.5 unless repeat is true, in which
         case it will be set to 0.
+
     colormap : string or matplotlib colormap, default="viridis"
         Matplotlib colormap to randomly draw colors from for each word.
+
     """
     text = s.str.cat(sep=" ")
 
@@ -162,11 +213,22 @@ def top_words(s: pd.Series, normalize=False) -> pd.Series:
     Return a pandas series with index the top words and as value the count.
 
     Tokenization: split by space and remove all punctuations that are not between characters.
-    
+
     Parameters
     ----------
-    normalize :
+    normalize : optional, default to False.
         When set to true, return normalized values.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> import texthero as hero
+    >>> s = pd.Series("one two two three three three")
+    >>> hero.top_words(s)
+    three    3
+    two      2
+    one      1
+    dtype: int64
 
     """
 

--- a/texthero/visualization.py
+++ b/texthero/visualization.py
@@ -54,17 +54,11 @@ def scatterplot(
     --------
     >>> import texthero as hero
     >>> import pandas as pd
-    >>> doc1 = "Football, Sports, Soccer"
-    >>> doc2 = "music, violin, orchestra"
-    >>> doc3 = "football, fun, sports"
-    >>> doc4 = "music, fun, guitar"
-    >>> df = pd.DataFrame([doc1, doc2, doc3, doc4], columns=["texts"])
-    >>> df["texts"] = hero.clean(df["texts"])
-    >>> df["texts"] = hero.tokenize(df["texts"])
-    >>> df["tfidf"] = hero.tfidf(df["texts"])
-    >>> df["topics"] = hero.kmeans(df["tfidf"], n_clusters=2)
-    >>> df["pca"] = hero.pca(df["tfidf"], n_components=3)
-    >>> hero.scatterplot(df, col="pca", color="topics", hover_name="texts") # doctest: +SKIP
+    >>> df = pd.DataFrame(["Football, Sports, Soccer", "music, violin, orchestra", "football, fun, sports"], columns=["texts"])
+    >>> df["texts"] = hero.clean(df["texts"]).pipe(hero.tokenize)
+    >>> df["pca"] = hero.tfidf(df["texts"]).pipe(hero.pca)
+    >>> df["topics"] = hero.tfidf(df["texts"]).pipe(hero.kmeans, n_clusters=2)
+    >>> hero.scatterplot(df, col="pca", color="topics", hover_data=["texts"]) # doctest: +SKIP
     """
 
     pca0 = df[col].apply(lambda x: x[0])


### PR DESCRIPTION
* Fix spelling / too long lines; add hyperlinks; improve explainations

* Add type information in signature (s: pd.Series), ...

* Improve module docstring at the very top

The other (functional) changes to `scatterplot` that were implemented in #107 (overhauling the function + adding 3D support + adding hover_name argument) will be in a separate PR once this is merged.