### PR TITLE
Implement decorator to handle NaNs in new _helper.py

### DIFF
--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,3 +1,7 @@
+"""
+Unit-tests for the helper module.
+"""
+
 import pandas as pd
 import numpy as np
 
@@ -23,7 +27,7 @@ Test Decorators.
 """
 
 
-class TestNLP(PandasTestCase):
+class TestHelpers(PandasTestCase):
     """
     handle_nans.
     """

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,72 @@
+import pandas as pd
+import numpy as np
+
+from . import PandasTestCase
+import doctest
+import unittest
+import warnings
+
+from texthero import _helper
+
+"""
+Doctests.
+"""
+
+
+def load_tests(loader, tests, ignore):
+    tests.addTests(doctest.DocTestSuite(_helper))
+    return tests
+
+
+"""
+Test Decorators.
+"""
+
+
+class TestNLP(PandasTestCase):
+    """
+    handle_nans.
+    """
+
+    def test_handle_nans(self):
+        s = pd.Series(["Test", np.nan, pd.NA])
+
+        @_helper.handle_nans(replace_nans_with="This was a NAN")
+        def f(s):
+            return s
+
+        s_true = pd.Series(["Test", "This was a NAN", "This was a NAN"])
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            self.assertEqual(f(s), s_true)
+
+        with self.assertWarns(Warning):
+            f(s)
+
+    def test_handle_nans_no_nans_in_input(self):
+        s = pd.Series(["Test"])
+
+        @_helper.handle_nans(replace_nans_with="This was a NAN")
+        def f(s):
+            return s
+
+        s_true = pd.Series(["Test"])
+
+        self.assertEqual(f(s), s_true)
+
+    # This is not in test_indexes.py as it requires a custom test case.
+    def test_handle_nans_index(self):
+        s = pd.Series(["Test", np.nan, pd.NA], index=[4, 5, 6])
+
+        @_helper.handle_nans(replace_nans_with="This was a NAN")
+        def f(s):
+            return s
+
+        s_true = pd.Series(
+            ["Test", "This was a NAN", "This was a NAN"], index=[4, 5, 6]
+        )
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            self.assertTrue(f(s).index.equals(s_true.index))

--- a/texthero/_helper.py
+++ b/texthero/_helper.py
@@ -1,0 +1,75 @@
+"""
+Useful helper functions for the texthero library.
+"""
+
+import functools
+import numpy as np
+import warnings
+
+from texthero.preprocessing import fillna
+
+
+"""
+Warnings.
+"""
+
+_warning_nans_in_input = (
+    "There are NaNs (missing values) in the given input series."
+    " They were replaced with appropriate values before the function"
+    " was applied. Consider using hero.fillna to replace those NaNs yourself"
+    " or hero.drop_no_content to remove them."
+)
+
+
+"""
+Decorators.
+"""
+
+
+def handle_nans(replace_nans_with):
+    """
+    Decorator to handle NaN values in a function's input.
+
+    Using the decorator, if there are NaNs in the input,
+    they are replaced with replace_nans_with
+    and a warning is printed.
+
+    The function must take as first input a Pandas Series.
+
+    Examples
+    --------
+    >>> from texthero._helper import *
+    >>> import pandas as pd
+    >>> import numpy as np
+    >>> @handle_nans(replace_nans_with="I was missing!")
+    ... def replace_b_with_c(s):
+    ...     return s.str.replace("b", "c")
+    >>> s_with_nan = pd.Series(["Test b", np.nan])
+    >>> replace_b_with_c(s_with_nan)
+    0            Test c
+    1    I was missing!
+    dtype: object
+    """
+
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+
+            # Get first input argument (the series) and replace the NaNs.
+            s = args[0]
+            if s.isnull().values.any():
+                warnings.warn(_warning_nans_in_input, Warning)
+                s = s.fillna(value=replace_nans_with)
+
+            # Put the series back into the input.
+            if args[1:]:
+                args = (s,) + args[1:]
+            else:
+                args = (s,)
+
+            # Apply function as usual.
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/texthero/_helper.py
+++ b/texthero/_helper.py
@@ -6,8 +6,6 @@ import functools
 import numpy as np
 import warnings
 
-from texthero.preprocessing import fillna
-
 
 """
 Warnings.
@@ -57,8 +55,8 @@ def handle_nans(replace_nans_with):
 
             # Get first input argument (the series) and replace the NaNs.
             s = args[0]
-            if s.isnull().values.any():
-                warnings.warn(_warning_nans_in_input, Warning)
+            if s.isna().values.any():
+                warnings.warn(_warning_nans_in_input, UserWarning)
                 s = s.fillna(value=replace_nans_with)
 
             # Put the series back into the input.

--- a/texthero/_helper.py
+++ b/texthero/_helper.py
@@ -36,7 +36,7 @@ def handle_nans(replace_nans_with):
 
     Examples
     --------
-    >>> from texthero._helper import *
+    >>> from texthero._helper import handle_nans
     >>> import pandas as pd
     >>> import numpy as np
     >>> @handle_nans(replace_nans_with="I was missing!")

--- a/texthero/_helper.py
+++ b/texthero/_helper.py
@@ -3,7 +3,6 @@ Useful helper functions for the texthero library.
 """
 
 import functools
-import numpy as np
 import warnings
 
 


### PR DESCRIPTION
- add tests in new test_helpers.py
- decorator is not used anywhere yet, that will be done after this is merged

As discussed last Monday, we will handle the NaNs much simpler than previously suggested by replacing them in the input when the functions don't already handle them on their own (e.g. with `s.str....` we don't need anything else). We believe this decorator is the simplest way to achieve this.