### PR TITLE
Speed up preprocessing module

### DIFF
--- a/texthero/preprocessing.py
+++ b/texthero/preprocessing.py
@@ -458,11 +458,67 @@ def clean(s: pd.Series, pipeline=None) -> pd.Series:
     """
 
     if not pipeline:
-        pipeline = get_default_pipeline()
+        return _optimised_default_clean(s)
 
     for f in pipeline:
         s = s.pipe(f)
     return s
+
+
+def _optimised_default_clean(s: pd.Series) -> pd.Series:
+    """
+    Applies the default clean pipeline in an optimised way to a series,
+    that is about 30% faster.
+
+    Default pipeline:
+     1. :meth:`texthero.preprocessing.fillna`
+     2. :meth:`texthero.preprocessing.lowercase`
+     3. :meth:`texthero.preprocessing.remove_digits`
+     4. :meth:`texthero.preprocessing.remove_punctuation`
+     5. :meth:`texthero.preprocessing.remove_diacritics`
+     6. :meth:`texthero.preprocessing.remove_stopwords`
+     7. :meth:`texthero.preprocessing.remove_whitespace`
+    """
+    return s.apply(_optimised_default_clean_single_cell)
+
+
+def _optimised_default_clean_single_cell(text: str) -> str:
+    """
+    Applies the default clean pipeline to one cell.
+
+    Default pipeline:
+     1. :meth:`texthero.preprocessing.fillna`
+     2. :meth:`texthero.preprocessing.lowercase`
+     3. :meth:`texthero.preprocessing.remove_digits`
+     4. :meth:`texthero.preprocessing.remove_punctuation`
+     5. :meth:`texthero.preprocessing.remove_diacritics`
+     6. :meth:`texthero.preprocessing.remove_stopwords`
+     7. :meth:`texthero.preprocessing.remove_whitespace`
+    """
+
+    # fillna
+    if pd.isna(text):
+        return ""
+
+    # lowercase
+    text = text.lower()
+
+    # remove digits and punctuation
+    pattern_digits_remove = r"\b\d+\b"
+    pattern_punctuation_remove = rf"([{string.punctuation}])+"
+    pattern_mixed_remove = pattern_digits_remove + "|" + pattern_punctuation_remove
+    text = re.sub(pattern_mixed_remove, "", text)
+
+    # remove diacritics
+    text = _remove_diacritics(text)
+
+    # remove stopwords
+    text = _replace_stopwords(text, _stopwords.DEFAULT, "")
+
+    # remove whitespace
+    text = " ".join(re.sub("\xa0", " ", text).split())
+
+    return text
 
 
 def has_content(s: pd.Series) -> pd.Series:


### PR DESCRIPTION
Looked at every function in the preprocessing module 😑 The only function we found, where it makes sense to speed up was the clean function 🧹  with the default pipeline. This is probably called with the default pipeline very often. The default pipeline loops through every function and we combined these into one pass in `_optimised_default_clean_single_cell(text: str)`, which is 30% faster than the default pipeline. Now when users call clean with the default pipeline, this function will be used. 
We understand, that this introduces code duality and more maintenance if bugs were fixed and changes to the default pipeline introduced, but we believe it makes sense, as the function is called so often. 🦝 