### PR TITLE
RepresentationSeries: count, term_frequency and tfidf

### DIFF
--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -11,7 +11,6 @@ import unittest
 import warnings
 
 from texthero import _helper
-from texthero.representation import flatten
 
 """
 Doctests.
@@ -75,56 +74,3 @@ class TestHelpers(PandasTestCase):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             self.assertTrue(f(s).index.equals(s_true.index))
-
-    """
-    flatten.
-    """
-
-    def test_flatten(self):
-        index = pd.MultiIndex.from_tuples(
-            [("doc0", "Word1"), ("doc0", "Word3"), ("doc1", "Word2")],
-            names=["document", "word"],
-        )
-        s = pd.Series([3, np.nan, 4], index=index)
-
-        s_true = pd.Series(
-            [[3.0, 0.0, np.nan], [0.0, 4.0, 0.0]], index=["doc0", "doc1"],
-        )
-
-        pd.testing.assert_series_equal(flatten(s), s_true, check_names=False)
-
-    def test_flatten_fill_missing_with(self):
-        index = pd.MultiIndex.from_tuples(
-            [("doc0", "Word1"), ("doc0", "Word3"), ("doc1", "Word2")],
-            names=["document", "word"],
-        )
-        s = pd.Series([3, np.nan, 4], index=index)
-
-        s_true = pd.Series(
-            [[3.0, "FILLED", np.nan], ["FILLED", 4.0, "FILLED"]],
-            index=["doc0", "doc1"],
-            name="document",
-        )
-
-        pd.testing.assert_series_equal(
-            flatten(s, fill_missing_with="FILLED"), s_true, check_names=False
-        )
-
-    def test_flatten_missing_row(self):
-        # Simulating a row with no features, so it's completely missing from
-        # the representation series.
-        index = pd.MultiIndex.from_tuples(
-            [("doc0", "Word1"), ("doc0", "Word3"), ("doc1", "Word2")],
-            names=["document", "word"],
-        )
-        s = pd.Series([3, np.nan, 4], index=index)
-
-        s_true = pd.Series(
-            [[3.0, 0.0, np.nan], [0.0, 4.0, 0.0], [0.0, 0.0, 0.0]],
-            index=["doc0", "doc1", "doc2"],
-            name="document",
-        )
-
-        pd.testing.assert_series_equal(
-            flatten(s, index=s_true.index), s_true, check_names=False
-        )

--- a/tests/test_indexes.py
+++ b/tests/test_indexes.py
@@ -58,15 +58,19 @@ test_cases_preprocessing = [
 test_cases_representation = [
     [
         "count",
-        representation.count,
-        (preprocessing.tokenize(s_text), None, 1, 1.0, False, False, True),
+        lambda x: representation.flatten(representation.count(x)),
+        (s_tokenized_lists,),
     ],
     [
         "term_frequency",
-        representation.term_frequency,
-        (preprocessing.tokenize(s_text), None, 1, 1.0, False, True),
+        lambda x: representation.flatten(representation.term_frequency(x)),
+        (s_tokenized_lists,),
     ],
-    ["tfidf", representation.tfidf, (s_text, None, 1, 1.0, False, True)],
+    [
+        "tfidf",
+        lambda x: representation.flatten(representation.tfidf(x)),
+        (s_tokenized_lists,),
+    ],
     ["pca", representation.pca, (s_numeric_lists, 0)],
     ["nmf", representation.nmf, (s_numeric_lists,)],
     ["tsne", representation.tsne, (s_numeric_lists,)],

--- a/tests/test_indexes.py
+++ b/tests/test_indexes.py
@@ -56,13 +56,17 @@ test_cases_preprocessing = [
 ]
 
 test_cases_representation = [
-    ["count", representation.count, (preprocessing.tokenize(s_text),),],
+    [
+        "count",
+        representation.count,
+        (preprocessing.tokenize(s_text), None, 1, 1.0, False, False, True),
+    ],
     [
         "term_frequency",
         representation.term_frequency,
-        (preprocessing.tokenize(s_text),),
+        (preprocessing.tokenize(s_text), None, 1, 1.0, False, True),
     ],
-    ["tfidf", representation.tfidf, (preprocessing.tokenize(s_text),)],
+    ["tfidf", representation.tfidf, (s_text, None, 1, 1.0, False, True)],
     ["pca", representation.pca, (s_numeric_lists, 0)],
     ["nmf", representation.nmf, (s_numeric_lists,)],
     ["tsne", representation.tsne, (s_numeric_lists,)],

--- a/tests/test_representation.py
+++ b/tests/test_representation.py
@@ -30,36 +30,45 @@ class TestRepresentation(PandasTestCase):
         s = pd.Series("a b c c")
         s = preprocessing.tokenize(s)
         s_true = pd.Series([[1, 1, 2]])
-        self.assertEqual(representation.count(s), s_true)
+        s_true.rename_axis("document", inplace=True)
+
+        self.assertEqual(representation.count(s, return_flat_series=True), s_true)
 
     def test_count_multiple_documents(self):
         s = pd.Series(["doc_one", "doc_two"])
         s = preprocessing.tokenize(s)
         s_true = pd.Series([[1, 0], [0, 1]])
-        self.assertEqual(representation.count(s), s_true)
+        s_true.rename_axis("document", inplace=True)
+
+        self.assertEqual(representation.count(s, return_flat_series=True), s_true)
 
     def test_count_not_lowercase(self):
         s = pd.Series(["one ONE"])
         s = preprocessing.tokenize(s)
         s_true = pd.Series([[1, 1]])
-        self.assertEqual(representation.count(s), s_true)
+        s_true.rename_axis("document", inplace=True)
+
+        self.assertEqual(representation.count(s, return_flat_series=True), s_true)
 
     def test_count_punctuation_are_kept(self):
         s = pd.Series(["one !"])
         s = preprocessing.tokenize(s)
         s_true = pd.Series([[1, 1]])
-        self.assertEqual(representation.count(s), s_true)
+        s_true.rename_axis("document", inplace=True)
+
+        self.assertEqual(representation.count(s, return_flat_series=True), s_true)
 
     def test_count_not_tokenized_yet(self):
         s = pd.Series("a b c c")
         s_true = pd.Series([[1, 1, 2]])
+        s_true.rename_axis("document", inplace=True)
 
         with warnings.catch_warnings():  # avoid print warning
             warnings.simplefilter("ignore")
-            self.assertEqual(representation.count(s), s_true)
+            self.assertEqual(representation.count(s, return_flat_series=True), s_true)
 
         with self.assertWarns(DeprecationWarning):  # check raise warning
-            representation.count(s)
+            representation.count(s, return_flat_series=True)
 
     """
     TF-IDF
@@ -83,14 +92,14 @@ class TestRepresentation(PandasTestCase):
             ]
         )
         s_true.rename_axis("document", inplace=True)
-        self.assertEqual(representation.tfidf(s), s_true)
+        self.assertEqual(representation.tfidf(s, return_flat_series=True), s_true)
 
     def test_tfidf_single_document(self):
         s = pd.Series("a", index=["yo"])
         s = preprocessing.tokenize(s)
         s_true = pd.Series([[1]], index=["yo"])
         s_true.rename_axis("document", inplace=True)
-        self.assertEqual(representation.tfidf(s), s_true)
+        self.assertEqual(representation.tfidf(s, return_flat_series=True), s_true)
 
     def test_tfidf_not_tokenized_yet(self):
         s = pd.Series("a")
@@ -99,17 +108,17 @@ class TestRepresentation(PandasTestCase):
 
         with warnings.catch_warnings():  # avoid print warning
             warnings.simplefilter("ignore")
-            self.assertEqual(representation.tfidf(s), s_true)
+            self.assertEqual(representation.tfidf(s, return_flat_series=True), s_true)
 
         with self.assertWarns(DeprecationWarning):  # check raise warning
-            representation.tfidf(s)
+            representation.tfidf(s, return_flat_series=True)
 
     def test_tfidf_single_not_lowercase(self):
         s = pd.Series("ONE one")
         s = preprocessing.tokenize(s)
         s_true = pd.Series([[1.0, 1.0]])
         s_true.rename_axis("document", inplace=True)
-        self.assertEqual(representation.tfidf(s), s_true)
+        self.assertEqual(representation.tfidf(s, return_flat_series=True), s_true)
 
     """
     Term Frequency
@@ -119,33 +128,211 @@ class TestRepresentation(PandasTestCase):
         s = pd.Series("a b c c")
         s = preprocessing.tokenize(s)
         s_true = pd.Series([[0.25, 0.25, 0.5]])
-        self.assertEqual(representation.term_frequency(s), s_true)
+        s_true.rename_axis("document", inplace=True)
+        self.assertEqual(
+            representation.term_frequency(s, return_flat_series=True), s_true,
+        )
 
     def test_term_frequency_multiple_documents(self):
         s = pd.Series(["doc_one", "doc_two"])
         s = preprocessing.tokenize(s)
         s_true = pd.Series([[0.5, 0.0], [0.0, 0.5]])
-        self.assertEqual(representation.term_frequency(s), s_true)
+        s_true.rename_axis("document", inplace=True)
+
+        self.assertEqual(
+            representation.term_frequency(s, return_flat_series=True), s_true
+        )
 
     def test_term_frequency_not_lowercase(self):
         s = pd.Series(["one ONE"])
         s = preprocessing.tokenize(s)
         s_true = pd.Series([[0.5, 0.5]])
-        self.assertEqual(representation.term_frequency(s), s_true)
+        s_true.rename_axis("document", inplace=True)
+
+        self.assertEqual(
+            representation.term_frequency(s, return_flat_series=True), s_true
+        )
 
     def test_term_frequency_punctuation_are_kept(self):
         s = pd.Series(["one !"])
         s = preprocessing.tokenize(s)
         s_true = pd.Series([[0.5, 0.5]])
-        self.assertEqual(representation.term_frequency(s), s_true)
+        s_true.rename_axis("document", inplace=True)
+
+        self.assertEqual(
+            representation.term_frequency(s, return_flat_series=True), s_true
+        )
 
     def test_term_frequency_not_tokenized_yet(self):
         s = pd.Series("a b c c")
         s_true = pd.Series([[0.25, 0.25, 0.5]])
+        s_true.rename_axis("document", inplace=True)
 
         with warnings.catch_warnings():  # avoid print warning
             warnings.simplefilter("ignore")
-            self.assertEqual(representation.term_frequency(s), s_true)
+            self.assertEqual(
+                representation.term_frequency(s, return_flat_series=True), s_true
+            )
 
         with self.assertWarns(DeprecationWarning):  # check raise warning
-            representation.term_frequency(s)
+            representation.term_frequency(s, return_flat_series=True)
+
+    """
+    Representation series testing
+    """
+
+    """
+    Count.
+    """
+
+    def test_count_single_document_representation_series(self):
+        s = pd.Series([list("abbcc")])
+
+        idx = pd.MultiIndex.from_tuples(
+            [(0, "a"), (0, "b"), (0, "c")], names=("document", "word")
+        )
+
+        s_true = pd.Series([1, 2, 2], index=idx, dtype="float").astype(
+            pd.SparseDtype("int", 0)
+        )
+        self.assertEqual(representation.count(s), s_true)
+
+    def test_count_multiple_documents_representation_series(self):
+
+        s = pd.Series([["doc_one"], ["doc_two"]])
+
+        idx = pd.MultiIndex.from_tuples(
+            [(0, "doc_one"), (1, "doc_two")], names=("document", "word")
+        )
+
+        s_true = pd.Series([1, 1], index=idx, dtype="float").astype(
+            pd.SparseDtype("int", 0)
+        )
+        self.assertEqual(representation.count(s), s_true)
+
+    def test_count_not_lowercase_representation_series(self):
+
+        s = pd.Series([["A"], ["a"]])
+
+        idx = pd.MultiIndex.from_tuples(
+            [(0, "A"), (1, "a")], names=("document", "word")
+        )
+
+        s_true = pd.Series([1, 1], index=idx, dtype="float").astype(
+            pd.SparseDtype("int", 0)
+        )
+        self.assertEqual(representation.count(s), s_true)
+
+    def test_count_punctuation_are_kept_representation_series(self):
+
+        s = pd.Series([["number", "one", "!", "?"]])
+
+        idx = pd.MultiIndex.from_tuples(
+            [(0, "!"), (0, "?"), (0, "number"), (0, "one")], names=("document", "word")
+        )
+
+        s_true = pd.Series([1, 1, 1, 1], index=idx, dtype="float").astype(
+            pd.SparseDtype("int", 0)
+        )
+        self.assertEqual(representation.count(s), s_true)
+
+    """
+    Term Frequency.
+    """
+
+    def test_term_frequency_single_document_representation_series(self):
+        s = pd.Series([list("abbcc")])
+
+        idx = pd.MultiIndex.from_tuples(
+            [(0, "a"), (0, "b"), (0, "c")], names=("document", "word")
+        )
+
+        s_true = pd.Series([0.2, 0.4, 0.4], index=idx, dtype="float").astype(
+            pd.SparseDtype("float", np.nan)
+        )
+        self.assertEqual(representation.term_frequency(s), s_true)
+
+    def test_term_frequency_multiple_documents_representation_series(self):
+
+        s = pd.Series([["doc_one"], ["doc_two"]])
+
+        idx = pd.MultiIndex.from_tuples(
+            [(0, "doc_one"), (1, "doc_two")], names=("document", "word")
+        )
+
+        s_true = pd.Series([0.5, 0.5], index=idx, dtype="float").astype(
+            pd.SparseDtype("float", np.nan)
+        )
+        self.assertEqual(representation.term_frequency(s), s_true)
+
+    def test_term_frequency_not_lowercase_representation_series(self):
+
+        s = pd.Series([["A"], ["a"]])
+
+        idx = pd.MultiIndex.from_tuples(
+            [(0, "A"), (1, "a")], names=("document", "word")
+        )
+
+        s_true = pd.Series([0.5, 0.5], index=idx, dtype="float").astype(
+            pd.SparseDtype("float", np.nan)
+        )
+        self.assertEqual(representation.term_frequency(s), s_true)
+
+    def test_term_frequency_punctuation_are_kept_representation_series(self):
+
+        s = pd.Series([["number", "one", "!", "?"]])
+
+        idx = pd.MultiIndex.from_tuples(
+            [(0, "!"), (0, "?"), (0, "number"), (0, "one")], names=("document", "word")
+        )
+
+        s_true = pd.Series([0.25, 0.25, 0.25, 0.25], index=idx, dtype="float").astype(
+            pd.SparseDtype("float", np.nan)
+        )
+        self.assertEqual(representation.term_frequency(s), s_true)
+
+    """
+    TF-IDF
+    """
+
+    def test_tfidf_simple_representation_series(self):
+        s = pd.Series([["a"]])
+
+        idx = pd.MultiIndex.from_tuples([(0, "a")], names=("document", "word"))
+        s_true = pd.Series([1.0], index=idx).astype("Sparse")
+        self.assertEqual(representation.tfidf(s), s_true)
+
+    def test_tfidf_single_not_lowercase_representation_series(self):
+        tfidf_single_smooth = 1.0
+
+        s = pd.Series([list("Aa")])
+
+        idx = pd.MultiIndex.from_tuples(
+            [(0, "A"), (0, "a")], names=("document", "word")
+        )
+
+        s_true = pd.Series(
+            [tfidf_single_smooth, tfidf_single_smooth], index=idx
+        ).astype("Sparse")
+
+        self.assertEqual(representation.tfidf(s), s_true)
+
+    def test_tfidf_single_different_index_representation_series(self):
+
+        idx = pd.MultiIndex.from_tuples(
+            [(10, "Bye"), (10, "Hi"), (11, "Bye"), (11, "Test")],
+            names=("document", "word"),
+        )
+        s_true = pd.Series(
+            [
+                1.0 * (math.log(3 / 3) + 1),
+                1.0 * (math.log(3 / 2) + 1),
+                2.0 * (math.log(3 / 3) + 1),
+                1.0 * (math.log(3 / 2) + 1),
+            ],
+            index=idx,
+        ).astype("Sparse")
+
+        s = pd.Series(["Hi Bye", "Test Bye Bye"], index=[10, 11])
+        s = preprocessing.tokenize(s)
+        self.assertEqual(representation.tfidf(s), s_true)

--- a/tests/test_representation.py
+++ b/tests/test_representation.py
@@ -195,7 +195,9 @@ class TestRepresentation(PandasTestCase):
         s_true = pd.Series([1, 2, 2], index=idx, dtype="float").astype(
             pd.SparseDtype("int", 0)
         )
-        pd.testing.assert_series_equal(representation.count(s), s_true, check_dtype=False)
+        pd.testing.assert_series_equal(
+            representation.count(s), s_true, check_dtype=False
+        )
 
     def test_count_multiple_documents_representation_series(self):
 
@@ -208,7 +210,9 @@ class TestRepresentation(PandasTestCase):
         s_true = pd.Series([1, 1], index=idx, dtype="float").astype(
             pd.SparseDtype("int", 0)
         )
-        pd.testing.assert_series_equal(representation.count(s), s_true, check_dtype=False)
+        pd.testing.assert_series_equal(
+            representation.count(s), s_true, check_dtype=False
+        )
 
     def test_count_not_lowercase_representation_series(self):
 
@@ -221,7 +225,9 @@ class TestRepresentation(PandasTestCase):
         s_true = pd.Series([1, 1], index=idx, dtype="float").astype(
             pd.SparseDtype("int", 0)
         )
-        pd.testing.assert_series_equal(representation.count(s), s_true, check_dtype=False)
+        pd.testing.assert_series_equal(
+            representation.count(s), s_true, check_dtype=False
+        )
 
     def test_count_punctuation_are_kept_representation_series(self):
 
@@ -234,7 +240,9 @@ class TestRepresentation(PandasTestCase):
         s_true = pd.Series([1, 1, 1, 1], index=idx, dtype="float").astype(
             pd.SparseDtype("int", 0)
         )
-        pd.testing.assert_series_equal(representation.count(s), s_true, check_dtype=False)
+        pd.testing.assert_series_equal(
+            representation.count(s), s_true, check_dtype=False
+        )
 
     """
     Term Frequency.

--- a/tests/test_representation.py
+++ b/tests/test_representation.py
@@ -32,7 +32,7 @@ class TestRepresentation(PandasTestCase):
         s_true = pd.Series([[1, 1, 2]])
         s_true.rename_axis("document", inplace=True)
 
-        self.assertEqual(representation.count(s, return_flat_series=True), s_true)
+        self.assertEqual(representation.flatten(representation.count(s)), s_true)
 
     def test_count_multiple_documents(self):
         s = pd.Series(["doc_one", "doc_two"])
@@ -40,7 +40,7 @@ class TestRepresentation(PandasTestCase):
         s_true = pd.Series([[1, 0], [0, 1]])
         s_true.rename_axis("document", inplace=True)
 
-        self.assertEqual(representation.count(s, return_flat_series=True), s_true)
+        self.assertEqual(representation.flatten(representation.count(s)), s_true)
 
     def test_count_not_lowercase(self):
         s = pd.Series(["one ONE"])
@@ -48,7 +48,7 @@ class TestRepresentation(PandasTestCase):
         s_true = pd.Series([[1, 1]])
         s_true.rename_axis("document", inplace=True)
 
-        self.assertEqual(representation.count(s, return_flat_series=True), s_true)
+        self.assertEqual(representation.flatten(representation.count(s)), s_true)
 
     def test_count_punctuation_are_kept(self):
         s = pd.Series(["one !"])
@@ -56,7 +56,7 @@ class TestRepresentation(PandasTestCase):
         s_true = pd.Series([[1, 1]])
         s_true.rename_axis("document", inplace=True)
 
-        self.assertEqual(representation.count(s, return_flat_series=True), s_true)
+        self.assertEqual(representation.flatten(representation.count(s)), s_true)
 
     def test_count_not_tokenized_yet(self):
         s = pd.Series("a b c c")
@@ -65,10 +65,10 @@ class TestRepresentation(PandasTestCase):
 
         with warnings.catch_warnings():  # avoid print warning
             warnings.simplefilter("ignore")
-            self.assertEqual(representation.count(s, return_flat_series=True), s_true)
+            self.assertEqual(representation.flatten(representation.count(s)), s_true)
 
         with self.assertWarns(DeprecationWarning):  # check raise warning
-            representation.count(s, return_flat_series=True)
+            representation.flatten(representation.count(s))
 
     """
     TF-IDF
@@ -92,14 +92,14 @@ class TestRepresentation(PandasTestCase):
             ]
         )
         s_true.rename_axis("document", inplace=True)
-        self.assertEqual(representation.tfidf(s, return_flat_series=True), s_true)
+        self.assertEqual(representation.flatten(representation.tfidf(s)), s_true)
 
     def test_tfidf_single_document(self):
         s = pd.Series("a", index=["yo"])
         s = preprocessing.tokenize(s)
         s_true = pd.Series([[1]], index=["yo"])
         s_true.rename_axis("document", inplace=True)
-        self.assertEqual(representation.tfidf(s, return_flat_series=True), s_true)
+        self.assertEqual(representation.flatten(representation.tfidf(s)), s_true)
 
     def test_tfidf_not_tokenized_yet(self):
         s = pd.Series("a")
@@ -108,17 +108,17 @@ class TestRepresentation(PandasTestCase):
 
         with warnings.catch_warnings():  # avoid print warning
             warnings.simplefilter("ignore")
-            self.assertEqual(representation.tfidf(s, return_flat_series=True), s_true)
+            self.assertEqual(representation.flatten(representation.tfidf(s)), s_true)
 
         with self.assertWarns(DeprecationWarning):  # check raise warning
-            representation.tfidf(s, return_flat_series=True)
+            representation.flatten(representation.tfidf(s))
 
     def test_tfidf_single_not_lowercase(self):
         s = pd.Series("ONE one")
         s = preprocessing.tokenize(s)
         s_true = pd.Series([[1.0, 1.0]])
         s_true.rename_axis("document", inplace=True)
-        self.assertEqual(representation.tfidf(s, return_flat_series=True), s_true)
+        self.assertEqual(representation.flatten(representation.tfidf(s)), s_true)
 
     """
     Term Frequency
@@ -130,7 +130,7 @@ class TestRepresentation(PandasTestCase):
         s_true = pd.Series([[0.25, 0.25, 0.5]])
         s_true.rename_axis("document", inplace=True)
         self.assertEqual(
-            representation.term_frequency(s, return_flat_series=True), s_true,
+            representation.flatten(representation.term_frequency(s)), s_true,
         )
 
     def test_term_frequency_multiple_documents(self):
@@ -140,7 +140,7 @@ class TestRepresentation(PandasTestCase):
         s_true.rename_axis("document", inplace=True)
 
         self.assertEqual(
-            representation.term_frequency(s, return_flat_series=True), s_true
+            representation.flatten(representation.term_frequency(s)), s_true,
         )
 
     def test_term_frequency_not_lowercase(self):
@@ -150,7 +150,7 @@ class TestRepresentation(PandasTestCase):
         s_true.rename_axis("document", inplace=True)
 
         self.assertEqual(
-            representation.term_frequency(s, return_flat_series=True), s_true
+            representation.flatten(representation.term_frequency(s)), s_true,
         )
 
     def test_term_frequency_punctuation_are_kept(self):
@@ -160,7 +160,7 @@ class TestRepresentation(PandasTestCase):
         s_true.rename_axis("document", inplace=True)
 
         self.assertEqual(
-            representation.term_frequency(s, return_flat_series=True), s_true
+            representation.flatten(representation.term_frequency(s)), s_true,
         )
 
     def test_term_frequency_not_tokenized_yet(self):
@@ -171,11 +171,11 @@ class TestRepresentation(PandasTestCase):
         with warnings.catch_warnings():  # avoid print warning
             warnings.simplefilter("ignore")
             self.assertEqual(
-                representation.term_frequency(s, return_flat_series=True), s_true
+                representation.flatten(representation.term_frequency(s)), s_true,
             )
 
         with self.assertWarns(DeprecationWarning):  # check raise warning
-            representation.term_frequency(s, return_flat_series=True)
+            representation.flatten(representation.term_frequency(s)), s_true,
 
     """
     Representation series testing

--- a/tests/test_representation.py
+++ b/tests/test_representation.py
@@ -192,8 +192,8 @@ class TestRepresentation(PandasTestCase):
             [(0, "a"), (0, "b"), (0, "c")], names=("document", "word")
         )
 
-        s_true = pd.Series([1, 2, 2], index=idx, dtype="float").astype(
-            pd.SparseDtype("int", 0)
+        s_true = pd.Series([1, 2, 2], index=idx, dtype=np.int64).astype(
+            pd.SparseDtype(np.int64, 0)
         )
         pd.testing.assert_series_equal(
             representation.count(s), s_true, check_dtype=False
@@ -207,8 +207,8 @@ class TestRepresentation(PandasTestCase):
             [(0, "doc_one"), (1, "doc_two")], names=("document", "word")
         )
 
-        s_true = pd.Series([1, 1], index=idx, dtype="float").astype(
-            pd.SparseDtype("int", 0)
+        s_true = pd.Series([1, 1], index=idx, dtype=np.int64).astype(
+            pd.SparseDtype(np.int64, 0)
         )
         pd.testing.assert_series_equal(
             representation.count(s), s_true, check_dtype=False
@@ -222,8 +222,8 @@ class TestRepresentation(PandasTestCase):
             [(0, "A"), (1, "a")], names=("document", "word")
         )
 
-        s_true = pd.Series([1, 1], index=idx, dtype="float").astype(
-            pd.SparseDtype("int", 0)
+        s_true = pd.Series([1, 1], index=idx, dtype=np.int64).astype(
+            pd.SparseDtype(np.int64, 0)
         )
         pd.testing.assert_series_equal(
             representation.count(s), s_true, check_dtype=False
@@ -237,11 +237,11 @@ class TestRepresentation(PandasTestCase):
             [(0, "!"), (0, "?"), (0, "number"), (0, "one")], names=("document", "word")
         )
 
-        s_true = pd.Series([1, 1, 1, 1], index=idx, dtype="float").astype(
-            pd.SparseDtype("int", 0)
+        s_true = pd.Series([1, 1, 1, 1], index=idx, dtype=np.int64).astype(
+            pd.SparseDtype(np.int64, 0)
         )
         pd.testing.assert_series_equal(
-            representation.count(s), s_true, check_dtype=False
+            representation.count(s), s_true,
         )
 
     """

--- a/tests/test_representation.py
+++ b/tests/test_representation.py
@@ -195,7 +195,7 @@ class TestRepresentation(PandasTestCase):
         s_true = pd.Series([1, 2, 2], index=idx, dtype="float").astype(
             pd.SparseDtype("int", 0)
         )
-        self.assertEqual(representation.count(s), s_true)
+        pd.testing.assert_series_equal(representation.count(s), s_true, check_dtype=False)
 
     def test_count_multiple_documents_representation_series(self):
 
@@ -208,7 +208,7 @@ class TestRepresentation(PandasTestCase):
         s_true = pd.Series([1, 1], index=idx, dtype="float").astype(
             pd.SparseDtype("int", 0)
         )
-        self.assertEqual(representation.count(s), s_true)
+        pd.testing.assert_series_equal(representation.count(s), s_true, check_dtype=False)
 
     def test_count_not_lowercase_representation_series(self):
 
@@ -221,7 +221,7 @@ class TestRepresentation(PandasTestCase):
         s_true = pd.Series([1, 1], index=idx, dtype="float").astype(
             pd.SparseDtype("int", 0)
         )
-        self.assertEqual(representation.count(s), s_true)
+        pd.testing.assert_series_equal(representation.count(s), s_true, check_dtype=False)
 
     def test_count_punctuation_are_kept_representation_series(self):
 
@@ -234,7 +234,7 @@ class TestRepresentation(PandasTestCase):
         s_true = pd.Series([1, 1, 1, 1], index=idx, dtype="float").astype(
             pd.SparseDtype("int", 0)
         )
-        self.assertEqual(representation.count(s), s_true)
+        pd.testing.assert_series_equal(representation.count(s), s_true, check_dtype=False)
 
     """
     Term Frequency.

--- a/tests/test_representation.py
+++ b/tests/test_representation.py
@@ -32,10 +32,24 @@ parameterized way.
 # Define valid inputs / outputs / indexes for different functions.
 s_not_tokenized = pd.Series(["This is not tokenized!"])
 s_tokenized = pd.Series([["Test", "Test", "TEST", "!"], ["Test", "?", ".", "."]])
+s_tokenized_with_noncontinuous_index = pd.Series(
+    [["Test", "Test", "TEST", "!"], ["Test", "?", ".", "."]], index=[5, 7]
+)
+
 s_tokenized_output_index = pd.MultiIndex.from_tuples(
     [(0, "!"), (0, "TEST"), (0, "Test"), (1, "."), (1, "?"), (1, "Test")],
     names=["document", "word"],
 )
+
+s_tokenized_output_noncontinuous_index = pd.MultiIndex.from_tuples(
+    [(5, "!"), (5, "TEST"), (5, "Test"), (7, "."), (7, "?"), (7, "Test")],
+    names=["document", "word"],
+)
+
+s_tokenized_output_min_df_index = pd.MultiIndex.from_tuples(
+    [(0, "Test"), (1, "Test")], names=["document", "word"],
+)
+
 
 test_cases_vectorization = [
     # format: [function_name, function, correct output for tokenized input above, dtype of output]
@@ -52,6 +66,13 @@ test_cases_vectorization = [
         [1.405465, 1.405465, 2.000000, 2.810930, 1.405465, 1.000000],
         "float",
     ],
+]
+
+test_cases_vectorization_min_df = [
+    # format: [function_name, function, correct output for tokenized input above, dtype of output]
+    ["count", representation.count, [2, 1], "int"],
+    ["term_frequency", representation.term_frequency, [0.666667, 0.333333], "float",],
+    ["tfidf", representation.tfidf, [2.0, 1.0], "float",],
 ]
 
 
@@ -83,9 +104,58 @@ class AbstractRepresentationTest(PandasTestCase):
         pd.testing.assert_series_equal(s_true, result_s)
 
     @parameterized.expand(test_cases_vectorization)
+    def test_vectorization_noncontinuous_index_kept(
+        self, name, test_function, correct_output_values, int_or_float
+    ):
+        if int_or_float == "int":
+            s_true = pd.Series(
+                correct_output_values,
+                index=s_tokenized_output_noncontinuous_index,
+                dtype="int",
+            ).astype(pd.SparseDtype(np.int64, 0))
+        else:
+            s_true = pd.Series(
+                correct_output_values,
+                index=s_tokenized_output_noncontinuous_index,
+                dtype="float",
+            ).astype(pd.SparseDtype("float", np.nan))
+
+        result_s = test_function(s_tokenized_with_noncontinuous_index)
+
+        pd.testing.assert_series_equal(s_true, result_s)
+
+    @parameterized.expand(test_cases_vectorization_min_df)
+    def test_vectorization_min_df(
+        self, name, test_function, correct_output_values, int_or_float
+    ):
+        if int_or_float == "int":
+            s_true = pd.Series(
+                correct_output_values,
+                index=s_tokenized_output_min_df_index,
+                dtype="int",
+            ).astype(pd.SparseDtype(np.int64, 0))
+        else:
+            s_true = pd.Series(
+                correct_output_values,
+                index=s_tokenized_output_min_df_index,
+                dtype="float",
+            ).astype(pd.SparseDtype("float", np.nan))
+
+        result_s = test_function(s_tokenized, min_df=2)
+
+        pd.testing.assert_series_equal(s_true, result_s)
+
+    @parameterized.expand(test_cases_vectorization)
     def test_vectorization_not_tokenized_yet_warning(self, name, test_function, *args):
         with self.assertWarns(DeprecationWarning):  # check raise warning
             test_function(s_not_tokenized)
+
+    @parameterized.expand(test_cases_vectorization)
+    def test_vectorization_arguments_to_sklearn(self, name, test_function, *args):
+        try:
+            test_function(s_not_tokenized, max_features=1, min_df=1, max_df=1.0)
+        except TypeError:
+            self.fail("Sklearn arguments not handled correctly.")
 
     """
     Individual / special tests.
@@ -108,3 +178,60 @@ class AbstractRepresentationTest(PandasTestCase):
         ).astype("Sparse")
 
         self.assertEqual(representation.tfidf(s), s_true)
+
+    """
+    flatten.
+    """
+
+    def test_flatten(self):
+        index = pd.MultiIndex.from_tuples(
+            [("doc0", "Word1"), ("doc0", "Word3"), ("doc1", "Word2")],
+            names=["document", "word"],
+        )
+        s = pd.Series([3, np.nan, 4], index=index)
+
+        s_true = pd.Series(
+            [[3.0, 0.0, np.nan], [0.0, 4.0, 0.0]], index=["doc0", "doc1"],
+        )
+
+        pd.testing.assert_series_equal(
+            representation.flatten(s), s_true, check_names=False
+        )
+
+    def test_flatten_fill_missing_with(self):
+        index = pd.MultiIndex.from_tuples(
+            [("doc0", "Word1"), ("doc0", "Word3"), ("doc1", "Word2")],
+            names=["document", "word"],
+        )
+        s = pd.Series([3, np.nan, 4], index=index)
+
+        s_true = pd.Series(
+            [[3.0, "FILLED", np.nan], ["FILLED", 4.0, "FILLED"]],
+            index=["doc0", "doc1"],
+            name="document",
+        )
+
+        pd.testing.assert_series_equal(
+            representation.flatten(s, fill_missing_with="FILLED"),
+            s_true,
+            check_names=False,
+        )
+
+    def test_flatten_missing_row(self):
+        # Simulating a row with no features, so it's completely missing from
+        # the representation series.
+        index = pd.MultiIndex.from_tuples(
+            [("doc0", "Word1"), ("doc0", "Word3"), ("doc1", "Word2")],
+            names=["document", "word"],
+        )
+        s = pd.Series([3, np.nan, 4], index=index)
+
+        s_true = pd.Series(
+            [[3.0, 0.0, np.nan], [0.0, 4.0, 0.0], [0.0, 0.0, 0.0]],
+            index=["doc0", "doc1", "doc2"],
+            name="document",
+        )
+
+        pd.testing.assert_series_equal(
+            representation.flatten(s, index=s_true.index), s_true, check_names=False
+        )

--- a/texthero/representation.py
+++ b/texthero/representation.py
@@ -84,8 +84,6 @@ def flatten(
 
     s = pd.Series(s.values.tolist(), index=s.index)
 
-    s.rename_axis("document", inplace=True)
-
     return s
 
 
@@ -178,13 +176,11 @@ def count(
     >>> import pandas as pd
     >>> s = pd.Series(["Sentence one", "Sentence two"]).pipe(hero.tokenize)
     >>> hero.count(s)
-    document  word    
-    0         Sentence    1
-              one         1
-    1         Sentence    1
-              two         1
+    0  Sentence    1
+       one         1
+    1  Sentence    1
+       two         1
     dtype: Sparse[int64, 0]
-
 
     See Also
     --------
@@ -215,8 +211,6 @@ def count(
 
     # Map word index to word name
     s_out.index = s_out.index.map(lambda x: (s.index[x[0]], features_names[x[1]]))
-
-    s_out.rename_axis(["document", "word"], inplace=True)
 
     return s_out
 
@@ -266,12 +260,11 @@ def term_frequency(
     >>> import pandas as pd
     >>> s = pd.Series(["Sentence one hey", "Sentence two"]).pipe(hero.tokenize)
     >>> hero.term_frequency(s)
-    document  word    
-    0         Sentence    0.2
-              hey         0.2
-              one         0.2
-    1         Sentence    0.2
-              two         0.2
+    0  Sentence    0.2
+       hey         0.2
+       one         0.2
+    1  Sentence    0.2
+       two         0.2
     dtype: Sparse[float64, nan]
 
     See Also
@@ -303,8 +296,6 @@ def term_frequency(
 
     # Map word index to word name
     s_out.index = s_out.index.map(lambda x: (s.index[x[0]], features_names[x[1]]))
-
-    s_out.rename_axis(["document", "word"], inplace=True)
 
     return s_out
 
@@ -373,7 +364,6 @@ def tfidf(s: pd.Series, max_features=None, min_df=1, max_df=1.0,) -> pd.Series:
     >>> import pandas as pd
     >>> s = pd.Series(["Hi Bye", "Test Bye Bye"]).pipe(hero.tokenize)
     >>> hero.tfidf(s) # doctest: +SKIP
-    document  word
     0         Bye     1.000000
               Hi      1.405465
     1         Bye     2.000000
@@ -412,8 +402,6 @@ def tfidf(s: pd.Series, max_features=None, min_df=1, max_df=1.0,) -> pd.Series:
     # Map word index to word name and keep original index of documents.
     feature_names = tfidf.get_feature_names()
     s_out.index = s_out.index.map(lambda x: (s.index[x[0]], feature_names[x[1]]))
-
-    s_out.rename_axis(["document", "word"], inplace=True)
 
     return s_out
 
@@ -699,7 +687,6 @@ def kmeans(
     >>> s = pd.Series(["Football, Sports, Soccer", "music, violin, orchestra", "football, fun, sports", "music, fun, guitar"])
     >>> s = s.pipe(hero.clean).pipe(hero.tokenize).pipe(hero.term_frequency).pipe(hero.flatten) # TODO: when others get Representation Support: remove flatten
     >>> hero.kmeans(s, n_clusters=2, random_state=42)
-    document
     0    1
     1    0
     2    1
@@ -797,7 +784,6 @@ def dbscan(
     >>> s = pd.Series(["Football, Sports, Soccer", "music, violin, orchestra", "football, fun, sports", "music, enjoy, guitar"])
     >>> s = s.pipe(hero.clean).pipe(hero.tokenize).pipe(hero.tfidf).pipe(hero.flatten) # TODO: when others get Representation Support: remove flatten
     >>> hero.dbscan(s, min_samples=1, eps=4)
-    document
     0    0
     1    1
     2    0

--- a/texthero/representation.py
+++ b/texthero/representation.py
@@ -196,7 +196,7 @@ def count(
     >>> import texthero as hero
     >>> import pandas as pd
     >>> s = pd.Series(["Sentence one", "Sentence two"]).pipe(hero.tokenize)
-    >>> hero.count(s, return_flat_series=True)
+    >>> hero.count(s, return_flat_series=True) # doctest: +SKIP
     document
     0    [1, 1.0, 0.0]
     1    [1, 0.0, 1.0]
@@ -207,7 +207,7 @@ def count(
     >>> import texthero as hero
     >>> import pandas as pd
     >>> s = pd.Series(["Sentence one", "Sentence two"]).pipe(hero.tokenize)
-    >>> hero.count(s, return_flat_series=True, return_feature_names=True)
+    >>> hero.count(s, return_flat_series=True, return_feature_names=True) # doctest: +SKIP
     (document
     0    [1, 1.0, 0.0]
     1    [1, 0.0, 1.0]

--- a/texthero/representation.py
+++ b/texthero/representation.py
@@ -26,10 +26,10 @@ Helper
 """
 
 
-def representation_series_to_flat_series(
+def flatten(
     s: Union[pd.Series, pd.Series.sparse],
     index: pd.Index = None,
-    fill_missing_with: Any = np.nan,
+    fill_missing_with: Any = 0.0,
 ) -> pd.Series:
     """
     Transform a Pandas Representation Series to a "normal" (flattened) Pandas Series.
@@ -47,7 +47,7 @@ def representation_series_to_flat_series(
     index : Pandas Index, optional, default to None
         The index the flattened Series should have.
 
-    fill_missing_with : Any, default to np.nan
+    fill_missing_with : Any, default to 0.0
         Value to fill the NaNs (missing values) with. This _does not_ mean
         that existing values that are np.nan are replaced, but rather that
         features that are not present in one document but present in others
@@ -67,7 +67,7 @@ def representation_series_to_flat_series(
               Word3    NaN
     doc1      Word2    4.0
     dtype: float64
-    >>> hero.representation_series_to_flat_series(s, fill_missing_with=0.0)
+    >>> hero.flatten(s, fill_missing_with=0.0)
     document
     doc0    [3.0, 0.0, nan]
     doc1    [0.0, 4.0, 0.0]
@@ -133,20 +133,21 @@ def count(
     min_df=1,
     max_df=1.0,
     binary=False,
-    return_feature_names=False,
-    return_flat_series=False,
 ) -> pd.Series:
     """
     Represent a text-based Pandas Series using count.
 
     Return a Document Representation Series with the
     number of occurences of a document's words for every
-    document. If return_flat_series is set to True,
-    return a Series with document vectors in every cell.
+    document.
     TODO add tutorial link
 
     The input Series should already be tokenized. If not, it will
     be tokenized before count is calculated.
+
+    Use :meth:`hero.representation.flatten` on the output to get
+    a standard Pandas Series with the document vectors
+    in every cell.
 
     Parameters
     ----------
@@ -171,13 +172,6 @@ def count(
     binary : bool, default=False
         If True, all non zero counts are set to 1.
 
-    return_features_names : Boolean, False by Default
-        If True, return a tuple (*count_series*, *features_names*)
-
-    return_flat_series : bool, default=False
-        Whether to return a flat Series (document vectors in every cell) instead
-        of a Document Representation Series. Will be less memory-efficient.
-
     Examples
     --------
     >>> import texthero as hero
@@ -191,27 +185,6 @@ def count(
               two         1
     dtype: Sparse[int64, 0]
 
-    With flat output:
-
-    >>> import texthero as hero
-    >>> import pandas as pd
-    >>> s = pd.Series(["Sentence one", "Sentence two"]).pipe(hero.tokenize)
-    >>> hero.count(s, return_flat_series=True) # doctest: +SKIP
-    document
-    0    [1, 1.0, 0.0]
-    1    [1, 0.0, 1.0]
-    dtype: object
-
-    To return the features_names:
-
-    >>> import texthero as hero
-    >>> import pandas as pd
-    >>> s = pd.Series(["Sentence one", "Sentence two"]).pipe(hero.tokenize)
-    >>> hero.count(s, return_flat_series=True, return_feature_names=True) # doctest: +SKIP
-    (document
-    0    [1, 1.0, 0.0]
-    1    [1, 0.0, 1.0]
-    dtype: object, ['Sentence', 'one', 'two'])
 
     See Also
     --------
@@ -245,37 +218,27 @@ def count(
 
     s_out.rename_axis(["document", "word"], inplace=True)
 
-    if return_flat_series:
-
-        s_out = representation_series_to_flat_series(
-            s_out, fill_missing_with=0.0, index=s.index
-        )
-
-        if return_feature_names:
-            return (s_out, tf.get_feature_names())
-
     return s_out
 
 
 def term_frequency(
-    s: pd.Series,
-    max_features: Optional[int] = None,
-    min_df=1,
-    max_df=1.0,
-    return_feature_names=False,
-    return_flat_series=False,
+    s: pd.Series, max_features: Optional[int] = None, min_df=1, max_df=1.0,
 ) -> pd.Series:
     """
     Represent a text-based Pandas Series using term frequency.
 
     Return a Document Representation Series with the
     term frequencies of the terms for every
-    document. If return_flat_series is set to True,
-    return a Series with document vectors in every cell.
+    document.
     TODO add tutorial link
 
     The input Series should already be tokenized. If not, it will
     be tokenized before term_frequency is calculated.
+
+    Use :meth:`hero.representation.flatten` on the output to get
+    a standard Pandas Series with the document vectors
+    in every cell.
+
 
     Parameters
     ----------
@@ -297,14 +260,6 @@ def term_frequency(
         If float, the parameter represents a proportion of documents, integer
         absolute counts.
 
-    return_features_names : Boolean, False by Default
-        If True, return a tuple (*count_series*, *features_names*)
-        Only applicable if return_flat_series is set to True.
-
-    return_flat_series : bool, default=False
-        Whether to return a flat Series (document vectors in every cell) instead
-        of a Document Representation Series. Will be less memory-efficient.
-
     Examples
     --------
     >>> import texthero as hero
@@ -318,28 +273,6 @@ def term_frequency(
     1         Sentence    0.2
               two         0.2
     dtype: Sparse[float64, nan]
-
-    With flat output:
-
-    >>> import texthero as hero
-    >>> import pandas as pd
-    >>> s = pd.Series(["Sentence one hey", "Sentence two"]).pipe(hero.tokenize)
-    >>> hero.term_frequency(s, return_flat_series=True)
-    document
-    0    [0.2, 0.2, 0.2, 0.0]
-    1    [0.2, 0.0, 0.0, 0.2]
-    dtype: object
-
-    To return the features_names with the flat output:
-
-    >>> import texthero as hero
-    >>> import pandas as pd
-    >>> s = pd.Series(["Sentence one hey", "Sentence two"]).pipe(hero.tokenize)
-    >>> hero.term_frequency(s, return_feature_names=True, return_flat_series=True)
-    (document
-    0    [0.2, 0.2, 0.2, 0.0]
-    1    [0.2, 0.0, 0.0, 0.2]
-    dtype: object, ['Sentence', 'hey', 'one', 'two'])
 
     See Also
     --------
@@ -373,26 +306,10 @@ def term_frequency(
 
     s_out.rename_axis(["document", "word"], inplace=True)
 
-    if return_flat_series:
-
-        s_out = representation_series_to_flat_series(
-            s_out, fill_missing_with=0.0, index=s.index
-        )
-
-        if return_feature_names:
-            return (s_out, tf.get_feature_names())
-
     return s_out
 
 
-def tfidf(
-    s: pd.Series,
-    max_features=None,
-    min_df=1,
-    max_df=1.0,
-    return_feature_names=False,
-    return_flat_series=False,
-) -> pd.Series:
+def tfidf(s: pd.Series, max_features=None, min_df=1, max_df=1.0,) -> pd.Series:
     """
     Represent a text-based Pandas Series using TF-IDF.
 
@@ -416,8 +333,7 @@ def tfidf(
     get applying the formula described above.
 
     Return a Document Representation Series with the
-    tfidf of every word in the document. If return_flat_series is set to True,
-    return a Series with document vectors in every cell.
+    tfidf of every word in the document.
     TODO add tutorial link
 
     The input Series should already be tokenized. If not, it will
@@ -425,6 +341,10 @@ def tfidf(
 
     If working with big pandas Series, you might want to limit
     the number of features through the max_features parameter.
+
+    Use :meth:`hero.representation.flatten` on the output to get
+    a standard Pandas Series with the document vectors
+    in every cell.
 
     Parameters
     ----------
@@ -447,13 +367,6 @@ def tfidf(
         If float, the parameter represents a proportion of documents, integer
         absolute counts.
 
-    return_feature_names: Boolean, optional, default to False
-        Whether to return the feature (i.e. word) names with the output.
-
-    return_flat_series : bool, default=False
-        Whether to return a flat Series (document vectors in every cell) instead
-        of a Document Representation Series. Will be less memory-efficient.
-
     Examples
     --------
     >>> import texthero as hero
@@ -466,17 +379,6 @@ def tfidf(
     1         Bye     2.000000
               Test    1.405465
     dtype: Sparse[float64, nan]
-
-    With flat output:
-
-    >>> import texthero as hero
-    >>> import pandas as pd
-    >>> s = pd.Series(["Hi Bye", "Test Bye Bye"]).pipe(hero.tokenize)
-    >>> hero.tfidf(s, return_feature_names=True, return_flat_series=True) # doctest: +SKIP
-    (document
-    0    [1.0, 1.4054651081081644, 0.0]
-    1    [2.0, 0.0, 1.4054651081081644]
-    dtype: object, ['Bye', 'Hi', 'Test'])
 
     See Also
     --------
@@ -512,14 +414,6 @@ def tfidf(
     s_out.index = s_out.index.map(lambda x: (s.index[x[0]], feature_names[x[1]]))
 
     s_out.rename_axis(["document", "word"], inplace=True)
-
-    if return_flat_series:
-        s_out = representation_series_to_flat_series(
-            s_out, fill_missing_with=0.0, index=s.index
-        )
-
-        if return_feature_names:
-            return (s_out, feature_names)
 
     return s_out
 
@@ -803,7 +697,7 @@ def kmeans(
     >>> import texthero as hero
     >>> import pandas as pd
     >>> s = pd.Series(["Football, Sports, Soccer", "music, violin, orchestra", "football, fun, sports", "music, fun, guitar"])
-    >>> s = s.pipe(hero.clean).pipe(hero.tokenize).pipe(hero.term_frequency, return_flat_series=True) # TODO: when others get Representation Support: remove argument
+    >>> s = s.pipe(hero.clean).pipe(hero.tokenize).pipe(hero.term_frequency).pipe(hero.flatten) # TODO: when others get Representation Support: remove flatten
     >>> hero.kmeans(s, n_clusters=2, random_state=42)
     document
     0    1
@@ -901,7 +795,7 @@ def dbscan(
     >>> import texthero as hero
     >>> import pandas as pd
     >>> s = pd.Series(["Football, Sports, Soccer", "music, violin, orchestra", "football, fun, sports", "music, enjoy, guitar"])
-    >>> s = s.pipe(hero.clean).pipe(hero.tokenize).pipe(hero.tfidf, return_flat_series=True) # TODO: when others get Representation Support: remove argument
+    >>> s = s.pipe(hero.clean).pipe(hero.tokenize).pipe(hero.tfidf).pipe(hero.flatten) # TODO: when others get Representation Support: remove flatten
     >>> hero.dbscan(s, min_samples=1, eps=4)
     document
     0    0

--- a/texthero/representation.py
+++ b/texthero/representation.py
@@ -363,11 +363,11 @@ def tfidf(s: pd.Series, max_features=None, min_df=1, max_df=1.0,) -> pd.Series:
     >>> import texthero as hero
     >>> import pandas as pd
     >>> s = pd.Series(["Hi Bye", "Test Bye Bye"]).pipe(hero.tokenize)
-    >>> hero.tfidf(s) # doctest: +SKIP
-    0         Bye     1.000000
-              Hi      1.405465
-    1         Bye     2.000000
-              Test    1.405465
+    >>> hero.tfidf(s)
+    0  Bye     1.000000
+       Hi      1.405465
+    1  Bye     2.000000
+       Test    1.405465
     dtype: Sparse[float64, nan]
 
     See Also

--- a/texthero/visualization.py
+++ b/texthero/visualization.py
@@ -62,8 +62,8 @@ def scatterplot(
     >>> import pandas as pd
     >>> df = pd.DataFrame(["Football, Sports, Soccer", "music, violin, orchestra", "football, fun, sports", "music, fun, guitar"], columns=["texts"])
     >>> df["texts"] = hero.clean(df["texts"]).pipe(hero.tokenize)
-    >>> df["pca"] = hero.tfidf(df["texts"], return_flat_series=True).pipe(hero.pca, n_components=3) # TODO: when others get Representation Support: remove argument
-    >>> df["topics"] = hero.tfidf(df["texts"], return_flat_series=True).pipe(hero.kmeans, n_clusters=2) # TODO: when others get Representation Support: remove argument
+    >>> df["pca"] = hero.tfidf(df["texts"]).pipe(hero.flatten).pipe(hero.pca, n_components=3) # TODO: when others get Representation Support: remove flatten
+    >>> df["topics"] = hero.tfidf(df["texts"]).pipe(hero.flatten).pipe(hero.kmeans, n_clusters=2) # TODO: when others get Representation Support: remove flatten
     >>> hero.scatterplot(df, col="pca", color="topics", hover_data=["texts"]) # doctest: +SKIP
     """
 

--- a/texthero/visualization.py
+++ b/texthero/visualization.py
@@ -62,8 +62,8 @@ def scatterplot(
     >>> import pandas as pd
     >>> df = pd.DataFrame(["Football, Sports, Soccer", "music, violin, orchestra", "football, fun, sports", "music, fun, guitar"], columns=["texts"])
     >>> df["texts"] = hero.clean(df["texts"]).pipe(hero.tokenize)
-    >>> df["pca"] = hero.tfidf(df["texts"]).pipe(hero.pca, n_components=3)
-    >>> df["topics"] = hero.tfidf(df["texts"]).pipe(hero.kmeans, n_clusters=2)
+    >>> df["pca"] = hero.tfidf(df["texts"], return_flat_series=True).pipe(hero.pca, n_components=3) # TODO: when others get Representation Support: remove argument
+    >>> df["topics"] = hero.tfidf(df["texts"], return_flat_series=True).pipe(hero.kmeans, n_clusters=2) # TODO: when others get Representation Support: remove argument
     >>> hero.scatterplot(df, col="pca", color="topics", hover_data=["texts"]) # doctest: +SKIP
     """
 


### PR DESCRIPTION
- Implement full support for Representation Series in "Vectorization" functions of representation module
- add appropriate tests
- add function` _check_is_valid_representation`

We already wrote & tested all the code for Representation Series in the whole module, but we want to split this up into separate PRs so it's easier to review etc. As soon as this is merged, we'll open the other PRs.

Roadmap for Representation Series implementation:
1. This PR
2. Implement Representation Series in rest of representation module over 2-3 more PRs
3. Write tutorial for Representation Series
4. Incorporate Representation Series into README and getting-started
5. Release to PyPI