### PR TITLE
Add normalization to representation module.

### DIFF
--- a/texthero/representation.py
+++ b/texthero/representation.py
@@ -960,7 +960,7 @@ def normalize(s: pd.Series, norm="l2") -> pd.Series:
             s = s.astype("Sparse")
             s_coo_matrix = s.sparse.to_coo()[0]
 
-        s_for_vectorization = s_coo_matrix.todense()
+        s_for_vectorization = s_coo_matrix
 
     else:
         s_for_vectorization = list(s)


### PR DESCRIPTION
- adds function `normalize` that takes Series and norm (supports `l1, l2, max` norms through `sklearn.preprocessing.normalize`)
- works on both representation series and flat / "normal" series (the sklearn normalize function can already handle both :clap: )
- after #132 is merged, will add more tests for normalize (doctests already cover the most important things)