### PR TITLE
Fix docstring line length

### DIFF
--- a/texthero/nlp.py
+++ b/texthero/nlp.py
@@ -13,12 +13,11 @@ def named_entities(s: pd.Series, package="spacy") -> pd.Series:
     Return a Pandas Series where each row contains a list of tuples
     with information about the named entities in the row's document.
 
-    Tuple: (`entity'name`, `entity'label`, `starting character`, `ending
-    character`)
+    Tuple: (`entity'name`, `entity'label`, `starting character`,
+            `ending character`)
 
-    Under the hood, `named_entities` makes use of
-    `Spacy name entity recognition
-    <https://spacy.io/usage/linguistic-features#named-entities>`_
+    Under the hood, `named_entities` makes use of `Spacy name entity
+    recognition <https://spacy.io/usage/linguistic-features#named-entities>`_
 
     List of labels:
      - `PERSON`: People, including fictional.
@@ -109,8 +108,8 @@ def count_sentences(s: pd.Series) -> pd.Series:
 
     Return a new Pandas Series with the number of sentences per cell.
 
-    This makes use of the SpaCy
-    `sentencizer <https://spacy.io/api/sentencizer>`_
+    This makes use of the SpaCy `sentencizer
+    <https://spacy.io/api/sentencizer>`_
 
     Examples
     --------
@@ -143,8 +142,8 @@ def pos_tag(s: pd.Series) -> pd.Series:
     Return new Pandas Series where each rows contains a list of tuples
     containing information about part-of-speech tagging.
 
-    Tuple (`token name`,`Coarse-grained POS`,`Fine-grained POS`, `starting
-    character`, `ending character`)
+    Tuple: (`token name`,`Coarse-grained POS`,`Fine-grained POS`,
+            `starting character`, `ending character`)
 
     A difference between the coarse-grained POS and the Fine-grained POS is
     that the last one is more specific about marking, for example if the
@@ -158,7 +157,7 @@ def pos_tag(s: pd.Series) -> pd.Series:
     You can see more details about Fine-grained POS at:
     <https://spacy.io/api/annotation#pos-en>
 
-    This makes use of the SpaCy `processing pipeline.
+    This makes use of the SpaCy `processing pipeline
     <https://spacy.io/usage/processing-pipelines#pipelines>`.
 
     List of POS/Tag:

--- a/texthero/nlp.py
+++ b/texthero/nlp.py
@@ -13,10 +13,12 @@ def named_entities(s: pd.Series, package="spacy") -> pd.Series:
     Return a Pandas Series where each row contains a list of tuples
     with information about the named entities in the row's document.
 
-    Tuple: (`entity'name`, `entity'label`, `starting character`, `ending character`)
+    Tuple: (`entity'name`, `entity'label`, `starting character`, `ending
+    character`)
 
-    Under the hood, `named_entities` makes use of 
-    `Spacy name entity recognition <https://spacy.io/usage/linguistic-features#named-entities>`_
+    Under the hood, `named_entities` makes use of
+    `Spacy name entity recognition
+    <https://spacy.io/usage/linguistic-features#named-entities>`_
 
     List of labels:
      - `PERSON`: People, including fictional.
@@ -43,8 +45,9 @@ def named_entities(s: pd.Series, package="spacy") -> pd.Series:
     >>> import texthero as hero
     >>> import pandas as pd
     >>> s = pd.Series("Yesterday I was in NY with Bill de Blasio")
-    >>> hero.named_entities(s)[0]
-    [('Yesterday', 'DATE', 0, 9), ('NY', 'GPE', 19, 21), ('Bill de Blasio', 'PERSON', 27, 41)]
+    >>> hero.named_entities(s)[0] # doctest: +NORMALIZE_WHITESPACE
+    [('Yesterday', 'DATE', 0, 9), ('NY', 'GPE', 19, 21),
+     ('Bill de Blasio', 'PERSON', 27, 41)]
     """
     entities = []
 
@@ -68,10 +71,10 @@ def noun_chunks(s: pd.Series) -> pd.Series:
 
     Tuple: (`chunk'text`, `chunk'label`, `starting index`, `ending index`)
 
-    Noun chunks or noun phrases are phrases that have noun at their head or nucleus 
-    i.e., they ontain the noun and other words that describe that noun. 
-    A detailed explanation on noun chunks: https://en.wikipedia.org/wiki/Noun_phrase
-    Internally `noun_chunks` makes use of Spacy's dependency parsing:
+    Noun chunks or noun phrases are phrases that have noun at their head or
+    nucleus i.e., they ontain the noun and other words that describe that noun.
+    A detailed explanation on noun chunks: https://en.wikipedia.org/wiki/Noun
+    phrase. Internally `noun_chunks` makes use of Spacy's dependency parsing:
     https://spacy.io/usage/linguistic-features#dependency-parse
 
     Examples
@@ -106,13 +109,16 @@ def count_sentences(s: pd.Series) -> pd.Series:
 
     Return a new Pandas Series with the number of sentences per cell.
 
-    This makes use of the SpaCy `sentencizer <https://spacy.io/api/sentencizer>`_
+    This makes use of the SpaCy
+    `sentencizer <https://spacy.io/api/sentencizer>`_
 
     Examples
     --------
     >>> import texthero as hero
     >>> import pandas as pd
-    >>> s = pd.Series(["Yesterday I was in NY with Bill de Blasio. Great story...", "This is the F.B.I.! What? Open up!"])
+    >>> s = pd.Series(
+    ...     ["Yesterday I was in NY with Bill de Blasio. Great story...",
+    ...      "This is the F.B.I.! What? Open up!"])
     >>> hero.count_sentences(s)
     0    2
     1    3
@@ -134,18 +140,26 @@ def pos_tag(s: pd.Series) -> pd.Series:
     """
     Return a Pandas Series with part-of-speech tagging
 
-    Return new Pandas Series where each rows contains a list of tuples containing information about part-of-speech tagging
+    Return new Pandas Series where each rows contains a list of tuples
+    containing information about part-of-speech tagging.
 
-    Tuple (`token name`,`Coarse-grained POS`,`Fine-grained POS`, `starting character`, `ending character`)
-    
-    A difference between the coarse-grained POS and the Fine-grained POS is that the last one is more specific about marking,
-    for example if the coarse-grained POS has a NOUN value, then the refined POS will give more details about the type of 
-    the noun, whether it is singular, plural and/or proper.
-    You can use the spacy `explain` function to find out which fine-grained POS it is.
-    
-    You can see more details about Fine-grained POS at: <https://spacy.io/api/annotation#pos-en>
+    Tuple (`token name`,`Coarse-grained POS`,`Fine-grained POS`, `starting
+    character`, `ending character`)
 
-    This makes use of the SpaCy `processing pipeline. <https://spacy.io/usage/processing-pipelines#pipelines>`.
+    A difference between the coarse-grained POS and the Fine-grained POS is
+    that the last one is more specific about marking, for example if the
+    coarse-grained POS has a NOUN value, then the refined POS will give more
+    details about the type of the noun, whether it is singular, plural and/or
+    proper.
+    
+    You can use the spacy `explain` function to find out which fine-grained
+    POS it is.
+
+    You can see more details about Fine-grained POS at:
+    <https://spacy.io/api/annotation#pos-en>
+
+    This makes use of the SpaCy `processing pipeline.
+    <https://spacy.io/usage/processing-pipelines#pipelines>`.
 
     List of POS/Tag:
      - `ADJ`: Adjective. Examples: big, old, green.
@@ -168,15 +182,18 @@ def pos_tag(s: pd.Series) -> pd.Series:
      - `X`: Other.
      - `SPACE`: Space.
 
-    Internally pos_tag makes use of Spacy's dependency tagging: <https://spacy.io/api/annotation#pos-tagging>`
+    Internally pos_tag makes use of Spacy's dependency tagging:
+    <https://spacy.io/api/annotation#pos-tagging>`
 
     Examples
     --------
     >>> import texthero as hero
     >>> import pandas as pd
     >>> s = pd.Series("Today is such a beautiful day")
-    >>> print(hero.pos_tag(s)[0])
-    [('Today', 'NOUN', 'NN', 0, 5), ('is', 'AUX', 'VBZ', 6, 8), ('such', 'DET', 'PDT', 9, 13), ('a', 'DET', 'DT', 14, 15), ('beautiful', 'ADJ', 'JJ', 16, 25), ('day', 'NOUN', 'NN', 26, 29)]
+    >>> print(hero.pos_tag(s)[0]) # doctest: +NORMALIZE_WHITESPACE
+    [('Today', 'NOUN', 'NN', 0, 5), ('is', 'AUX', 'VBZ', 6, 8), ('such', 'DET',
+     'PDT', 9, 13), ('a', 'DET', 'DT', 14, 15), ('beautiful', 'ADJ', 'JJ', 16,
+     25), ('day', 'NOUN', 'NN', 26, 29)]
     """
 
     pos_tags = []

--- a/texthero/preprocessing.py
+++ b/texthero/preprocessing.py
@@ -25,7 +25,7 @@ warnings.filterwarnings(action="ignore", category=UserWarning, module="gensim")
 
 def fillna(s: pd.Series) -> pd.Series:
     """
-    Replaces not assigned values with empty spaces.
+    Replaces not assigned values with empty string.
 
 
     Examples
@@ -63,7 +63,8 @@ def replace_digits(s: pd.Series, symbols: str = " ", only_blocks=True) -> pd.Ser
     """
     Replace all digits with symbols.
 
-    By default, only replaces "blocks" of digits, i.e tokens composed of only numbers.
+    By default, only replaces "blocks" of digits, i.e tokens composed of only
+    numbers.
 
     When `only_blocks` is set to ´False´, replaces all digits.
 
@@ -101,7 +102,8 @@ def remove_digits(s: pd.Series, only_blocks=True) -> pd.Series:
     """
     Remove all digits and replaces them with a single space.
 
-    By default, only remove "blocks" of digits. For instance, `1234 falcon9` becomes ` falcon9`.
+    By default, only remove "blocks" of digits. For instance, `1234 falcon9`
+    becomes ` falcon9`.
 
     When the arguments `only_blocks` is set to ´False´, remove any digits.
 
@@ -165,9 +167,11 @@ def remove_punctuation(s: pd.Series) -> pd.Series:
     Replace all punctuation with a single space (" ").
 
     Remove all punctuation from the given Pandas Series and replace it
-    with a single space. It considers as punctuation characters all :data:`string.punctuation` symbols `!"#$%&\'()*+,-./:;<=>?@[\\]^_`{|}~).`
+    with a single space. It considers as punctuation characters all
+    :data:`string.punctuation` symbols `!"#$%&\'()*+,-./:;<=>?@[\\]^_`{|}~).`
 
-    See also :meth:`replace_punctuation` to replace punctuation with a custom symbol.
+    See also :meth:`replace_punctuation` to replace punctuation with a custom
+    symbol.
 
     Examples
     --------
@@ -203,14 +207,16 @@ def remove_diacritics(s: pd.Series) -> pd.Series:
     """
     Remove all diacritics and accents.
 
-    Remove all diacritics and accents from any word and characters from the given Pandas Series.
+    Remove all diacritics and accents from any word and characters from the
+    given Pandas Series.
     Return a cleaned version of the Pandas Series.
 
     Examples
     --------
     >>> import texthero as hero
     >>> import pandas as pd
-    >>> s = pd.Series("Montréal, über, 12.89, Mère, Françoise, noël, 889, اِس, اُس")
+    >>> s = pd.Series(
+    ...     "Montréal, über, 12.89, Mère, Françoise, noël, 889, اِس, اُس")
     >>> hero.remove_diacritics(s)[0]
     'Montreal, uber, 12.89, Mere, Francoise, noel, 889, اس, اس'
 
@@ -291,7 +297,8 @@ def replace_stopwords(
         Character(s) to replace words with.
 
     stopwords : Set[str], Optional
-        Set of stopwords string to remove. If not passed, by default it used NLTK English stopwords. 
+        Set of stopwords string to remove. If not passed, by default it used
+        NLTK English stopwords. 
 
     Examples
     --------
@@ -322,7 +329,8 @@ def remove_stopwords(
     s : Pandas Series
 
     stopwords : Set[str], Optional
-        Set of stopwords string to remove. If not passed, by default it used NLTK English stopwords.
+        Set of stopwords string to remove. If not passed, by default it used
+        NLTK English stopwords.
 
     Examples
     --------
@@ -357,10 +365,16 @@ def stem(s: pd.Series, stem="snowball", language="english") -> pd.Series:
     r"""
     Stem series using either `porter` or `snowball` NLTK stemmers.
 
-    The act of stemming means removing the end of a words with an heuristic process.
-    It's useful in context where the meaning of the word is important rather than his derivation. Stemming is very efficient and adapt in case the given dataset is large.
+    The act of stemming means removing the end of a words with an heuristic
+    process.
+    It's useful in context where the meaning of the word is important rather
+    than his derivation. Stemming is very efficient and adapt in case the given
+    dataset is large.
 
-    Make use of two NLTK stemming algorithms known as :class:`nltk.stem.SnowballStemmer` and :class:`nltk.stem.PorterStemmer`. SnowballStemmer should be used when the Pandas Series contains non-English text has it has multilanguage support.
+    Make use of two NLTK stemming algorithms known as
+    :class:`nltk.stem.SnowballStemmer` and :class:`nltk.stem.PorterStemmer`.
+    SnowballStemmer should be used when the Pandas Series contains non-English
+    text has it has multilanguage support.
 
 
     Parameters
@@ -371,7 +385,9 @@ def stem(s: pd.Series, stem="snowball", language="english") -> pd.Series:
         Stemming algorithm. It can be either 'snowball' or 'porter'
 
     language : str (english by default)
-        Supported languages: `danish`, `dutch`, `english`, `finnish`, `french`, `german` , `hungarian`, `italian`, `norwegian`, `portuguese`, `romanian`, `russian`, `spanish` and `swedish`.
+        Supported languages: `danish`, `dutch`, `english`, `finnish`, `french`,
+        `german` , `hungarian`, `italian`, `norwegian`, `portuguese`,
+        `romanian`, `russian`, `spanish` and `swedish`.
 
     Notes
     -----
@@ -402,7 +418,8 @@ def stem(s: pd.Series, stem="snowball", language="english") -> pd.Series:
 
 def get_default_pipeline() -> List[Callable[[pd.Series], pd.Series]]:
     """
-    Return a list contaning all the methods used in the default cleaning pipeline.
+    Return a list contaning all the methods used in the default cleaning
+    pipeline.
 
     Return a list with the following functions:
      1. :meth:`texthero.preprocessing.fillna`
@@ -426,7 +443,8 @@ def get_default_pipeline() -> List[Callable[[pd.Series], pd.Series]]:
 
 def clean(s: pd.Series, pipeline=None) -> pd.Series:
     """
-    Pre-process a text-based Pandas Series, by using the following default pipline.
+    Pre-process a text-based Pandas Series, by using the following default
+    pipeline.
 
      Default pipeline:
      1. :meth:`texthero.preprocessing.fillna`
@@ -488,7 +506,8 @@ def drop_no_content(s: pd.Series) -> pd.Series:
     r"""
     Drop all rows without content.
 
-    Every row from a given Pandas Series, where :meth:`has_content` is False, will be dropped.
+    Every row from a given Pandas Series, where :meth:`has_content` is False,
+    will be dropped.
 
     Examples
     --------
@@ -530,7 +549,8 @@ def remove_round_brackets(s: pd.Series) -> pd.Series:
 
 def remove_curly_brackets(s: pd.Series) -> pd.Series:
     """
-    Remove content within curly brackets '{}' and the curly brackets by themself.
+    Remove content within curly brackets '{}' and the curly brackets by
+    themselves.
 
     Examples
     --------
@@ -554,7 +574,8 @@ def remove_curly_brackets(s: pd.Series) -> pd.Series:
 
 def remove_square_brackets(s: pd.Series) -> pd.Series:
     """
-    Remove content within square brackets '[]' and the square brackets by themself.
+    Remove content within square brackets '[]' and the square brackets by
+    themselves.
 
     Examples
     --------
@@ -579,7 +600,8 @@ def remove_square_brackets(s: pd.Series) -> pd.Series:
 
 def remove_angle_brackets(s: pd.Series) -> pd.Series:
     """
-    Remove content within angle brackets '<>' and the angle brackets by themself.
+    Remove content within angle brackets '<>' and the angle brackets by
+    themselves.
 
     Examples
     --------
@@ -637,8 +659,9 @@ def remove_html_tags(s: pd.Series) -> pd.Series:
     """
     Remove html tags from the given Pandas Series.
 
-    Remove all html tags of the type `<.*?>` such as <html>, <p>, <div class="hello"> and
-    remove all html tags of type &nbsp and return a cleaned Pandas Series.
+    Remove all html tags of the type `<.*?>` such as <html>, <p>,
+    <div class="hello"> and remove all html tags of type &nbsp and return a
+    cleaned Pandas Series.
 
     Examples
     --------
@@ -651,8 +674,8 @@ def remove_html_tags(s: pd.Series) -> pd.Series:
 
     """
 
-    pattern = r"""(?x)                    # Turn on free-spacing
-      <[^>]+>                             # Remove <html> tags
+    pattern = r"""(?x)                              # Turn on free-spacing
+      <[^>]+>                                       # Remove <html> tags
       | &([a-z0-9]+|\#[0-9]{1,6}|\#x[0-9a-f]{1,6}); # Remove &nbsp;
       """
 
@@ -663,8 +686,8 @@ def tokenize(s: pd.Series) -> pd.Series:
     """
     Tokenize each row of the given Series.
 
-    Tokenize each row of the given Pandas Series and return a Pandas Series where
-    each row contains a list of tokens.
+    Tokenize each row of the given Pandas Series and return a Pandas Series
+    where each row contains a list of tokens.
 
     Algorithm: add a space between any punctuation symbol at
     exception if the symbol is between two alphanumeric character and split.
@@ -681,7 +704,9 @@ def tokenize(s: pd.Series) -> pd.Series:
     """
 
     punct = string.punctuation.replace("_", "")
-    # In regex, the metacharacter 'w' is "a-z, A-Z, 0-9, including the _ (underscore) character." We therefore remove it from the punctuation string as this is already included in \w
+    # In regex, the metacharacter 'w' is "a-z, A-Z, 0-9, including the _ (underscore)
+    # character." We therefore remove it from the punctuation string as this is already
+    # included in \w.
 
     pattern = rf"((\w)([{punct}])(?:\B|$)|(?:^|\B)([{punct}])(\w))"
 
@@ -806,7 +831,8 @@ def remove_urls(s: pd.Series) -> pd.Series:
 def replace_tags(s: pd.Series, symbol: str) -> pd.Series:
     """Replace all tags from a given Pandas Series with symbol.
 
-    A tag is a string formed by @ concatenated with a sequence of characters and digits. Example: @texthero123.
+    A tag is a string formed by @ concatenated with a sequence of characters
+    and digits. Example: @texthero123.
 
     Parameters
     ----------
@@ -833,7 +859,8 @@ def replace_tags(s: pd.Series, symbol: str) -> pd.Series:
 def remove_tags(s: pd.Series) -> pd.Series:
     """Remove all tags from a given Pandas Series.
 
-    A tag is a string formed by @ concatenated with a sequence of characters and digits. Example: @texthero123. Tags are replaceb by an empty space ` `.
+    A tag is a string formed by @ concatenated with a sequence of characters
+    and digits. Example: @texthero123. Tags are replaceb by an empty space ` `.
 
     Examples
     --------
@@ -846,7 +873,8 @@ def remove_tags(s: pd.Series) -> pd.Series:
 
     See also
     --------
-    :meth:`texthero.preprocessing.replace_tags` for replacing a tag with a custom symbol.
+    :meth:`texthero.preprocessing.replace_tags` for replacing a tag with a
+        custom symbol.
     """
     return replace_tags(s, " ")
 
@@ -854,7 +882,8 @@ def remove_tags(s: pd.Series) -> pd.Series:
 def replace_hashtags(s: pd.Series, symbol: str) -> pd.Series:
     """Replace all hashtags from a Pandas Series with symbol
 
-    A hashtag is a string formed by # concatenated with a sequence of characters, digits and underscores. Example: #texthero_123. 
+    A hashtag is a string formed by # concatenated with a sequence of
+    characters, digits and underscores. Example: #texthero_123. 
 
     Parameters
     ----------
@@ -880,7 +909,8 @@ def replace_hashtags(s: pd.Series, symbol: str) -> pd.Series:
 def remove_hashtags(s: pd.Series) -> pd.Series:
     """Remove all hashtags from a given Pandas Series
 
-    A hashtag is a string formed by # concatenated with a sequence of characters, digits and underscores. Example: #texthero_123. 
+    A hashtag is a string formed by # concatenated with a sequence of
+    characters, digits and underscores. Example: #texthero_123. 
 
     Examples
     --------
@@ -893,6 +923,7 @@ def remove_hashtags(s: pd.Series) -> pd.Series:
 
     See also
     --------
-    :meth:`texthero.preprocessing.replace_hashtags` for replacing a hashtag with a custom symbol.
+    :meth:`texthero.preprocessing.replace_hashtags` for replacing a hashtag
+        with a custom symbol.
     """
     return replace_hashtags(s, " ")

--- a/texthero/representation.py
+++ b/texthero/representation.py
@@ -33,12 +33,14 @@ def flatten(
     fill_missing_with: Any = 0.0,
 ) -> pd.Series:
     """
-    Transform a Pandas Representation Series to a "normal" (flattened) Pandas Series.
+    Transform a Pandas Representation Series to a "normal" (flattened) Pandas
+    Series.
 
-    The given Series should have a multiindex with first level being the document
-    and second level being individual features of that document (e.g. tdidf scores per word).
-    The flattened Series has one cell per document, with the cell being a list of all
-    the individual features of that document.
+    The given Series should have a multiindex with first level being the
+    document and second level being individual features of that document
+    (e.g. tdidf scores per word). The flattened Series has one cell per
+    document, with the cell being a list of all the individual features of
+    that document.
 
     Parameters
     ----------
@@ -60,7 +62,9 @@ def flatten(
     >>> import texthero as hero
     >>> import pandas as pd
     >>> import numpy as np
-    >>> index = pd.MultiIndex.from_tuples([("doc0", "Word1"), ("doc0", "Word3"), ("doc1", "Word2")], names=['document', 'word'])
+    >>> index = pd.MultiIndex.from_tuples(
+    ...         [("doc0", "Word1"), ("doc0", "Word3"), ("doc1", "Word2")],
+    ...          names=['document', 'word'])
     >>> s = pd.Series([3, np.nan, 4], index=index)
     >>> s
     document  word 
@@ -153,7 +157,8 @@ def count(
     s : Pandas Series (tokenized)
 
     max_features : int, optional, default to None.
-        Maximum number of features to keep. Will keep all features if set to None.
+        Maximum number of features to keep. Will keep all features if set to
+        None.
 
     min_df : float in range [0.0, 1.0] or int, default=1
         When building the vocabulary ignore terms that have a document
@@ -163,8 +168,8 @@ def count(
         absolute counts.
 
     max_df : float in range [0.0, 1.0] or int, default=1.0
-        Ignore terms that have a document frequency (number of documents they appear in)
-        frequency strictly higher than the given threshold.
+        Ignore terms that have a document frequency (number of documents they
+        appear in) frequency strictly higher than the given threshold.
         If float, the parameter represents a proportion of documents, integer
         absolute counts.
 
@@ -240,7 +245,8 @@ def term_frequency(
     s : Pandas Series (tokenized)
 
     max_features : int, optional, default to None.
-        Maximum number of features to keep. Will keep all features if set to None.
+        Maximum number of features to keep. Will keep all features if set to
+        None.
 
     min_df : float in range [0.0, 1.0] or int, default=1
         When building the vocabulary ignore terms that have a document
@@ -250,8 +256,8 @@ def term_frequency(
         absolute counts.
 
     max_df : float in range [0.0, 1.0] or int, default=1.0
-        Ignore terms that have a document frequency (number of documents they appear in)
-        frequency strictly higher than the given threshold.
+        Ignore terms that have a document frequency (number of documents they
+        appear in) frequency strictly higher than the given threshold.
         If float, the parameter represents a proportion of documents, integer
         absolute counts.
 
@@ -307,22 +313,24 @@ def tfidf(s: pd.Series, max_features=None, min_df=1, max_df=1.0,) -> pd.Series:
 
     *Term Frequency - Inverse Document Frequency (TF-IDF)* is a formula to
     calculate the _relative importance_ of the words in a document, taking
-    into account the words' occurences in other documents. It consists of two parts:
+    into account the words' occurences in other documents. It consists of two
+    parts:
 
-    The *term frequency (tf)* tells us how frequently a term is present in a document,
-    so tf(document d, term t) = number of times t appears in d.
+    The *term frequency (tf)* tells us how frequently a term is present in a
+    document, so tf(document d, term t) = number of times t appears in d.
 
-    The *inverse document frequency (idf)* measures how _important_ or _characteristic_
-    a term is among the whole corpus (i.e. among all documents).
-    Thus, idf(term t) = log((1 + number of documents) / (1 + number of documents where t is present)) + 1.
+    The *inverse document frequency (idf)* measures how _important_ or
+    _characteristic_ a term is among the whole corpus (i.e. among all
+    documents). Thus, idf(term t) = log((1 + number of documents) /
+    (1 + number of documents where t is present)) + 1.
 
     Finally, tf-idf(document d, term t) = tf(d, t) * idf(t).
 
     Different from the `sklearn-implementation of 
-    tfidf <https://scikit-learn.org/stable/modules/generated/sklearn.feature_extraction.text.TfidfVectorizer.html>`,
-    this function does *not* normalize the output in any way,
-    so the result is exactly what you
-    get applying the formula described above.
+    tfidf <https://scikit-learn.org/stable/modules/generated/sklearn.feature_
+    extraction.text.TfidfVectorizer.html>`, this function does *not* normalize
+    the output in any way, so the result is exactly what you get applying the
+    formula described above.
 
     Return a Document Representation Series with the
     tfidf of every word in the document.
@@ -353,8 +361,8 @@ def tfidf(s: pd.Series, max_features=None, min_df=1, max_df=1.0,) -> pd.Series:
         absolute counts.
 
     max_df : float in range [0.0, 1.0] or int, default=1.0
-        Ignore terms that have a document frequency (number of documents they appear in)
-        frequency strictly higher than the given threshold.
+        Ignore terms that have a document frequency (number of documents they
+        appear in) frequency strictly higher than the given threshold.
         This arguments basically permits to remove corpus-specific stop words.
         If float, the parameter represents a proportion of documents, integer
         absolute counts.
@@ -419,18 +427,20 @@ def pca(s, n_components=2, random_state=None) -> pd.Series:
     Principal Component Analysis (PCA) is a statistical method that is used
     to reveal where the variance in a dataset comes from. For textual data,
     one could for example first represent a Series of documents using
-    :meth:`texthero.representation.tfidf` to get a vector representation
-    of each document. Then, PCA can generate new vectors from the tfidf representation
-    that showcase the differences among the documents most strongly in fewer dimensions.
+    :meth:`texthero.representation.tfidf` to get a vector representation of
+    each document. Then, PCA can generate new vectors from the tfidf
+    representation that showcase the differences among the documents most
+    strongly in fewer dimensions.
 
-    For example, the tfidf vectors will have length 100 if hero.tfidf was called
-    on a large corpus with max_features=100. Visualizing 100 dimensions is hard!
-    Using PCA with n_components=3, every document will now get a vector of
-    length 3, and the vectors will be chosen so that the document differences
-    are easily visible. The corpus can now be visualized in 3D and we can
-    get a good first view of the data!
+    For example, the tfidf vectors will have length 100 if hero.tfidf was
+    called on a large corpus with max_features=100. Visualizing 100 dimensions
+    is hard! Using PCA with n_components=3, every document will now get a
+    vector of length 3, and the vectors will be chosen so that the document
+    differences are easily visible. The corpus can now be visualized in 3D and
+    we can get a good first view of the data!
 
-    In general, *pca* should be called after the text has already been represented to a matrix form.
+    In general, *pca* should be called after the text has already been
+    represented to a matrix form.
 
     Parameters
     ----------
@@ -446,13 +456,15 @@ def pca(s, n_components=2, random_state=None) -> pd.Series:
 
     Returns
     -------
-    Pandas Series with the vector calculated by PCA for the document in every cell.
+    Pandas Series with the vector calculated by PCA for the document in every
+    cell.
 
     Examples
     --------
     >>> import texthero as hero
     >>> import pandas as pd
-    >>> s = pd.Series(["Football is great", "Hi, I'm Texthero, who are you? Tell me!"])
+    >>> s = pd.Series(["Football is great",
+    ...                "Hi, I'm Texthero, who are you? Tell me!"])
     >>> s = s.pipe(hero.clean).pipe(hero.tokenize).pipe(hero.tfidf)
     >>> # Attention, your results might differ due to
     >>> # the randomness in PCA!
@@ -482,11 +494,11 @@ def nmf(s, n_components=2, random_state=None) -> pd.Series:
     of technical terms; see the example below). 
 
     Given a document-term matrix (so in
-    texthero usually a Series after applying :meth:`texthero.representation.tfidf`
-    or some other first representation function that assigns a scalar (a weight)
-    to each word), NMF will find n_components many topics (clusters)
-    and calculate a vector for each document that places it
-    correctly among the topics.
+    texthero usually a Series after applying
+    :meth:`texthero.representation.tfidf` or some other first representation
+    function that assigns a scalar (a weight) to each word), NMF will find
+    n_components many topics (clusters) and calculate a vector for each
+    document that places it correctly among the topics.
 
 
     Parameters
@@ -502,13 +514,15 @@ def nmf(s, n_components=2, random_state=None) -> pd.Series:
 
     Returns
     -------
-    Pandas Series with the vector calculated by NMF for the document in every cell.
+    Pandas Series with the vector calculated by NMF for the document in every
+    cell.
 
     Examples
     --------
     >>> import texthero as hero
     >>> import pandas as pd
-    >>> s = pd.Series(["Football, Sports, Soccer", "Music, Violin, Orchestra", "Football, Music"])
+    >>> s = pd.Series(["Football, Sports, Soccer", "Music, Violin, Orchestra",
+    ...                "Football, Music"])
     >>> s = s.pipe(hero.clean).pipe(hero.tokenize).pipe(hero.term_frequency)
     >>> hero.nmf(s) # doctest: +SKIP
     0                    [0.9080190347553924, 0.0]
@@ -523,7 +537,8 @@ def nmf(s, n_components=2, random_state=None) -> pd.Series:
 
     See also
     --------
-    `NMF on Wikipedia <https://en.wikipedia.org/wiki/Non-negative_matrix_factorization>`_
+    `NMF on Wikipedia
+    <https://en.wikipedia.org/wiki/Non-negative_matrix_factorization>`_
 
     """
     nmf = NMF(n_components=n_components, init="random", random_state=random_state,)
@@ -543,16 +558,14 @@ def tsne(
     Performs TSNE on the given pandas series.
 
     t-distributed Stochastic Neighbor Embedding (t-SNE) is
-    a machine learning algorithm used to visualize high-dimensional data in fewer
-    dimensions. In natural language processing, the high-dimensional
-    data is usually a document-term matrix
-    (so in texthero usually a Series after applying :meth:`texthero.representation.tfidf`
-    or some other first representation function that assigns a scalar (a weight)
-    to each word) that is hard to visualize as there
-    might be many terms. With t-SNE, every document
-    gets a new, low-dimensional (n_components entries)
-    vector in such a way that the differences / similarities between
-    documents are preserved.
+    a machine learning algorithm used to visualize high-dimensional data in
+    fewer dimensions. In natural language processing, the high-dimensional data
+    is usually a document-term matrix (so in texthero usually a Series after
+    applying :meth:`texthero.representation.tfidf` or some other first
+    representation function that assigns a scalar (a weight) to each word)
+    that is hard to visualize as there might be many terms. With t-SNE, every
+    document gets a new, low-dimensional (n_components entries) vector in such
+    a way that the differences / similarities between documents are preserved.
 
 
     Parameters
@@ -592,13 +605,15 @@ def tsne(
 
     Returns
     -------
-    Pandas Series with the vector calculated by t-SNE for the document in every cell.
+    Pandas Series with the vector calculated by t-SNE for the document in every
+    cell.
 
     Examples
     --------
     >>> import texthero as hero
     >>> import pandas as pd
-    >>> s = pd.Series(["Football, Sports, Soccer", "Music, Violin, Orchestra", "Football, Music"])
+    >>> s = pd.Series(["Football, Sports, Soccer", "Music, Violin, Orchestra",
+    ...                "Football, Music"])
     >>> s = s.pipe(hero.clean).pipe(hero.tokenize).pipe(hero.term_frequency)
     >>> hero.tsne(s, random_state=42) # doctest: +SKIP
     0      [-18.833383560180664, -276.800537109375]
@@ -608,7 +623,8 @@ def tsne(
 
     See also
     --------
-    `t-SNE on Wikipedia <https://en.wikipedia.org/wiki/T-distributed_stochastic_neighbor_embedding>`_
+    `t-SNE on Wikipedia <https://en.wikipedia.org/wiki/T-distributed_
+    stochastic_neighbor_embedding>`_
 
     """
     tsne = TSNE(
@@ -646,10 +662,10 @@ def kmeans(
     to separate them into two clusters). 
 
     Given a document-term matrix (so in
-    texthero usually a Series after applying :meth:`texthero.representation.tfidf`
-    or some other first representation function that assigns a scalar (a weight)
-    to each word), K-means will find k topics (clusters)
-    and assign a topic to each document.
+    texthero usually a Series after applying
+    :meth:`texthero.representation.tfidf` or some other first representation
+    function that assigns a scalar (a weight) to each word), K-means will find
+    k topics (clusters) and assign a topic to each document.
 
     Parameters
     ----------
@@ -685,8 +701,12 @@ def kmeans(
     --------
     >>> import texthero as hero
     >>> import pandas as pd
-    >>> s = pd.Series(["Football, Sports, Soccer", "music, violin, orchestra", "football, fun, sports", "music, fun, guitar"])
-    >>> s = s.pipe(hero.clean).pipe(hero.tokenize).pipe(hero.term_frequency).pipe(hero.flatten) # TODO: when others get Representation Support: remove flatten
+    >>> s = pd.Series(["Football, Sports, Soccer", "music, violin, orchestra",
+    ...                "football, fun, sports", "music, fun, guitar"])
+    >>> s = s.pipe(hero.clean) \
+             .pipe(hero.tokenize) \
+             .pipe(hero.term_frequency) \
+             .pipe(hero.flatten) # TODO: when others get Representation Support: remove flatten
     >>> hero.kmeans(s, n_clusters=2, random_state=42)
     0    1
     1    0
@@ -736,10 +756,10 @@ def dbscan(
     number of clusters on its own.
 
     Given a document-term matrix (so in
-    texthero usually a Series after applying :meth:`texthero.representation.tfidf`
-    or some other first representation function that assigns a scalar (a weight)
-    to each word), DBSCAN will find topics (clusters)
-    and assign a topic to each document.
+    texthero usually a Series after applying
+    :meth:`texthero.representation.tfidf` or some other first representation
+    function that assigns a scalar (a weight) to each word), DBSCAN will find
+    topics (clusters) and assign a topic to each document.
 
     Parameters
     ----------
@@ -782,8 +802,12 @@ def dbscan(
     --------
     >>> import texthero as hero
     >>> import pandas as pd
-    >>> s = pd.Series(["Football, Sports, Soccer", "music, violin, orchestra", "football, fun, sports", "music, enjoy, guitar"])
-    >>> s = s.pipe(hero.clean).pipe(hero.tokenize).pipe(hero.tfidf).pipe(hero.flatten) # TODO: when others get Representation Support: remove flatten
+    >>> s = pd.Series(["Football, Sports, Soccer", "music, violin, orchestra",
+    ...                "football, fun, sports", "music, enjoy, guitar"])
+    >>> s = s.pipe(hero.clean) \
+             .pipe(hero.tokenize) \
+             .pipe(hero.tfidf) \
+             .pipe(hero.flatten) # TODO: when others get Representation Support: remove flatten
     >>> hero.dbscan(s, min_samples=1, eps=4)
     0    0
     1    1
@@ -836,10 +860,10 @@ def meanshift(
     number of clusters on its own.
 
     Given a document-term matrix (so in
-    texthero usually a Series after applying :meth:`texthero.representation.tfidf`
-    or some other first representation function that assigns a scalar (a weight)
-    to each word), mean shift will find topics (clusters)
-    and assign a topic to each document.
+    texthero usually a Series after applying
+    :meth:`texthero.representation.tfidf` or some other first representation
+    function that assigns a scalar (a weight) to each word), mean shift will
+    find topics (clusters) and assign a topic to each document.
 
     Parameters
     ----------
@@ -849,8 +873,9 @@ def meanshift(
         Bandwidth used in the RBF kernel.
 
         If not given, the bandwidth is estimated.
-        Estimating takes time at least quadratic in the number of samples (i.e. documents).
-        For large datasets, it’s wise to set the bandwidth to a small value.
+        Estimating takes time at least quadratic in the number of samples
+        (i.e. documents). For large datasets, it’s wise to set the bandwidth
+        to a small value.
 
     bin_seeding : bool, default=False
         If true, initial kernel locations are not locations of all
@@ -943,8 +968,8 @@ def normalize(s: pd.Series, norm="l2") -> pd.Series:
     >>> import texthero as hero
     >>> import pandas as pd
     >>> idx = pd.MultiIndex.from_tuples(
-    ...             [(0, "a"), (0, "b"), (1, "c"), (1, "d")], names=("document", "word")
-    ...         )
+    ...             [(0, "a"), (0, "b"), (1, "c"), (1, "d")],
+    ...              names=("document", "word"))
     >>> s = pd.Series([1, 2, 3, 4], index=idx)
     >>> hero.normalize(s, norm="max")
     document  word

--- a/texthero/representation.py
+++ b/texthero/representation.py
@@ -703,10 +703,12 @@ def kmeans(
     >>> import pandas as pd
     >>> s = pd.Series(["Football, Sports, Soccer", "music, violin, orchestra",
     ...                "football, fun, sports", "music, fun, guitar"])
-    >>> s = s.pipe(hero.clean) \
-             .pipe(hero.tokenize) \
-             .pipe(hero.term_frequency) \
-             .pipe(hero.flatten) # TODO: when others get Representation Support: remove flatten
+    >>> s = (
+    ...     s.pipe(hero.clean)
+    ...      .pipe(hero.tokenize)
+    ...      .pipe(hero.term_frequency)
+    ...      .pipe(hero.flatten)
+    ... ) # TODO: when others get Representation Support: remove flatten
     >>> hero.kmeans(s, n_clusters=2, random_state=42)
     0    1
     1    0
@@ -804,10 +806,12 @@ def dbscan(
     >>> import pandas as pd
     >>> s = pd.Series(["Football, Sports, Soccer", "music, violin, orchestra",
     ...                "football, fun, sports", "music, enjoy, guitar"])
-    >>> s = s.pipe(hero.clean) \
-             .pipe(hero.tokenize) \
-             .pipe(hero.tfidf) \
-             .pipe(hero.flatten) # TODO: when others get Representation Support: remove flatten
+    >>> s = (
+    ...     s.pipe(hero.clean)
+    ...      .pipe(hero.tokenize)
+    ...      .pipe(hero.tfidf)
+    ...      .pipe(hero.flatten)
+    ... )      # TODO: when others get Representation Support: remove flatten
     >>> hero.dbscan(s, min_samples=1, eps=4)
     0    0
     1    1

--- a/texthero/visualization.py
+++ b/texthero/visualization.py
@@ -40,13 +40,16 @@ def scatterplot(
     df: DataFrame with a column to be visualized.
 
     col: str
-        The name of the column of the DataFrame to use for x and y (and z) axis.
+        The name of the column of the DataFrame to use for x and y (and z)
+        axis.
 
     color: str, default to None.
-        Name of the column to use for coloring (rows with same value get same color).
+        Name of the column to use for coloring (rows with same value get same
+        color).
 
     hover_name: str, default to None
-        Name of the column to supply title of hover data when hovering over a point.
+        Name of the column to supply title of hover data when hovering over a
+        point.
 
     hover_data: List[str], default to [].
         List of column names to supply data when hovering over a point.
@@ -61,11 +64,16 @@ def scatterplot(
     --------
     >>> import texthero as hero
     >>> import pandas as pd
-    >>> df = pd.DataFrame(["Football, Sports, Soccer", "music, violin, orchestra", "football, fun, sports", "music, fun, guitar"], columns=["texts"])
+    >>> df = pd.DataFrame(["Football, Sports, Soccer",
+    ...                    "music, violin, orchestra", "football, fun, sports",
+    ...                    "music, fun, guitar"], columns=["texts"])
     >>> df["texts"] = hero.clean(df["texts"]).pipe(hero.tokenize)
-    >>> df["pca"] = hero.tfidf(df["texts"]).pipe(hero.flatten).pipe(hero.pca, n_components=3) # TODO: when others get Representation Support: remove flatten
-    >>> df["topics"] = hero.tfidf(df["texts"]).pipe(hero.flatten).pipe(hero.kmeans, n_clusters=2) # TODO: when others get Representation Support: remove flatten
-    >>> hero.scatterplot(df, col="pca", color="topics", hover_data=["texts"]) # doctest: +SKIP
+    >>> df["pca"] = hero.tfidf(df["texts"]).pipe(hero.flatten) \
+                                           .pipe(hero.pca, n_components=3) # TODO: when others get Representation Support: remove flatten
+    >>> df["topics"] = hero.tfidf(df["texts"]).pipe(hero.flatten) \
+                                              .pipe(hero.kmeans, n_clusters=2) # TODO: when others get Representation Support: remove flatten
+    >>> hero.scatterplot(df, col="pca", color="topics",
+    ...                  hover_data=["texts"]) # doctest: +SKIP
     """
 
     plot_values = np.stack(df[col], axis=1)
@@ -252,7 +260,8 @@ def top_words(s: TextSeries, normalize=False) -> pd.Series:
     r"""
     Return a pandas series with index the top words and as value the count.
 
-    Tokenization: split by space and remove all punctuations that are not between characters.
+    Tokenization: split by space and remove all punctuations that are not
+    between characters.
 
     Parameters
     ----------

--- a/texthero/visualization.py
+++ b/texthero/visualization.py
@@ -68,10 +68,16 @@ def scatterplot(
     ...                    "music, violin, orchestra", "football, fun, sports",
     ...                    "music, fun, guitar"], columns=["texts"])
     >>> df["texts"] = hero.clean(df["texts"]).pipe(hero.tokenize)
-    >>> df["pca"] = hero.tfidf(df["texts"]).pipe(hero.flatten) \
-                                           .pipe(hero.pca, n_components=3) # TODO: when others get Representation Support: remove flatten
-    >>> df["topics"] = hero.tfidf(df["texts"]).pipe(hero.flatten) \
-                                              .pipe(hero.kmeans, n_clusters=2) # TODO: when others get Representation Support: remove flatten
+    >>> df["pca"] = (
+    ...             hero.tfidf(df["texts"])
+    ...                 .pipe(hero.flatten)
+    ...                 .pipe(hero.pca, n_components=3)
+    ... ) # TODO: when others get Representation Support: remove flatten
+    >>> df["topics"] = (
+    ...                hero.tfidf(df["texts"])
+    ...                    .pipe(hero.flatten)
+    ...                    .pipe(hero.kmeans, n_clusters=2)
+    ... ) # TODO: when others get Representation Support: remove flatten
     >>> hero.scatterplot(df, col="pca", color="topics",
     ...                  hover_data=["texts"]) # doctest: +SKIP
     """


### PR DESCRIPTION
This is a follow through on #136. 

Fixed docstring line length of `preprocessing`, `representation`, and `visualization` modules to respect numpy docstring guide of 75 characters max length. `TODO`s in docstrings were left untouched.