### PR TITLE
Implement train_test_split

### DIFF
--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -381,3 +381,78 @@ class TestPreprocessing(PandasTestCase):
         s_true = pd.Series("Hi  , we will remove you")
 
         self.assertEqual(preprocessing.remove_hashtags(s), s_true)
+
+    """
+    Test train_test_split
+    """
+
+    def test_train_test_split(self):
+        df = pd.DataFrame(["Here", "hello", "there", "Test"])
+        train_set, test_set = preprocessing.train_test_split(
+            df, random_state=42, test=0.5
+        )
+        df_train_true = pd.DataFrame(["Here", "there"], index=[0, 2])
+        df_test_true = pd.DataFrame(["hello", "Test"], index=[1, 3])
+        pd.testing.assert_frame_equal(train_set, df_train_true)
+        pd.testing.assert_frame_equal(test_set, df_test_true)
+
+    def test_train_test_split_wrong_param(self):
+        df = pd.DataFrame(["Here", "hello", "there", "Test"])
+        self.assertRaises(
+            ValueError, preprocessing.train_test_split, df=df, random_state=42, val=0.4
+        )
+
+    def test_train_test_split_wrong_param_2(self):
+        df = pd.DataFrame(["Here", "hello", "there", "Test"])
+        self.assertRaises(
+            ValueError,
+            preprocessing.train_test_split,
+            df=df,
+            random_state=42,
+            train=5,
+            test=3,
+        )
+
+    def test_train_test_val_split(self):
+        df = pd.DataFrame(["Here", "hello", "there", "Test"])
+        train_set, test_set, val_set = preprocessing.train_test_split(
+            df, random_state=42, test=0.5, val=0.25
+        )
+        df_train_true = pd.DataFrame(["there"], index=[2])
+        df_test_true = pd.DataFrame(["Test", "Here"], index=[3, 0])
+        df_val_true = pd.DataFrame(["hello"], index=[1])
+
+        pd.testing.assert_frame_equal(train_set, df_train_true)
+        pd.testing.assert_frame_equal(test_set, df_test_true)
+        pd.testing.assert_frame_equal(val_set, df_val_true)
+
+    def test_train_val_split_class_balance(self):
+        df = pd.DataFrame(
+            [
+                ["Here", 1],
+                ["hello", 1],
+                ["hello", 1],
+                ["there", 0],
+                ["there", 0],
+                ["Test", 0],
+                ["Bang", 2],
+                ["Bang", 2],
+                ["Bang", 2],
+            ]
+        )
+        train_set, test_set, val_set = preprocessing.train_test_split(
+            df, random_state=42, test=0.33, val=0.33, class_balance=df[1]
+        )
+        df_train_true = pd.DataFrame(
+            [["hello", 1], ["Bang", 2], ["there", 0]], index=[1, 6, 3]
+        )
+        df_test_true = pd.DataFrame(
+            [["Here", 1], ["Test", 0], ["Bang", 2]], index=[0, 5, 7]
+        )
+        df_val_true = pd.DataFrame(
+            [["hello", 1], ["Bang", 2], ["there", 0]], index=[2, 8, 4]
+        )
+
+        pd.testing.assert_frame_equal(train_set, df_train_true)
+        pd.testing.assert_frame_equal(test_set, df_test_true)
+        pd.testing.assert_frame_equal(val_set, df_val_true)

--- a/texthero/preprocessing.py
+++ b/texthero/preprocessing.py
@@ -1118,3 +1118,17 @@ def train_test_split(
                                    :], df.loc[index_test_and_val, :]
 
         return df_train, df_test
+
+
+"""
+train_df, test_df = train_test_split(
+    df,
+    class_balance = df["topic"]
+)
+
+train_df["topic"].value_counts() / train_df["topic"].value_counts().sum()
+
+    test_df["topic"].value_counts() / test_df["topic"].value_counts().sum()
+
+
+"""


### PR DESCRIPTION
Implemented the method *train_test_split* to prepare a DataFrame for machine learning algorithms, by dividing it into 2-3 smaller DataFrames, which represent the train, test (and optionally validation) sets and additional test. The idea is that users are working with a DataFrame that has columns `text, pca, ..., X, Y` where columns `X, Y` are columns with input and labels/output (e.g. X might be a bert embedding of the text, Y might be class targets and users want to train an ML model to predict the labels). Most users currently use `sklearn.train_test_split` which we also internally use in the new function, but with this function we
- provide a unified interface for users (don't have to import sklearn for their ML preprocessing pipeline)
-  extend the sklearn function to split into train-test-validation (sklearn can only split into train-test)

## Overview
```python
def train_test_split(df,train=0.0,test=0.0,val=0.0,class_balance=None,shuffle=True,random_state=None) -> 
Union[
    Tuple[pd.DataFrame, pd.DataFrame], Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]
]:
```
Here the method takes:
-  a DataFrame that we want to split up into training, testing, and optionally validation.
- train=0.0,test=0.0,val=0.0, where, when all are set to 0.0, then the proportion will be 70% training set and 30% test set. If just validation is set, then we will return an error, as no training and test sizes are defined. If ints instead of floats are given, it will interpret this as the absolute value (e.g. train=200 -> train DF will have 200 documents)
- class_balance: if the data is already labeled and we want to keep the label proportions in the subsets (same as sklearn `stratify`), we pass a Series with the labels here (see example below)
- shuffle, which shuffles the dataset
- random_state, to create deterministic results

The method will return 2 or 3 DataFrames in a Tuple, with at the first 🥇 position the train_set_DataFrame, at the second 🥈 place the test_set_DataFrame and if validation was set to a different value than 0.0 it will return on the third 🥉 place the validation_set_DataFrame.


## Example

```python

>>> import texthero as hero
>>> import pandas as pd
>>> df = pd.read_csv(
...    "https://raw.githubusercontent.com/jbesomi/texthero/master/dataset/bbcsport.csv"
... ) # doctest: +SKIP
>>> train_df, test_df = hero.train_test_split(
...                  df, class_balance = df["topic"], random_state = 42, train=0.8
... ) # doctest: +SKIP
>>> len(train_df) # doctest: +SKIP
589
>>> len(test_df) # doctest: +SKIP
148
>>> # to check wether we have a equal class distribution (in this case a class is a topic)
>>> # we will look at the percentage of each topic in the DataFrame
>>> train_df["topic"].value_counts() / train_df["topic"].value_counts().sum() # doctest: +SKIP
football     0.359932
rugby        0.198642
cricket      0.168081
athletics    0.137521
tennis       0.135823
Name: topic, dtype: float64
>>> # and now the same for the test dataset
>>> test_df["topic"].value_counts() / test_df["topic"].value_counts().sum() # doctest: +SKIP
football     0.358108
rugby        0.202703
cricket      0.168919
athletics    0.135135
tennis       0.135135
Name: topic, dtype: float64
```