### PR TITLE
Fix type checks to not fail if first value in series is NaN/missing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ jobs:
       env: PATH=/c/Python38:/c/Python38/Scripts:$PATH
 install: 
     - pip3 install --upgrade pip  # all three OSes agree about 'pip3'
-    - pip3 install black
+    - pip3 install black==19.10b0
     - pip3 install ".[dev]" .
 # 'python' points to Python 2.7 on macOS but points to Python 3.8 on Linux and Windows
 # 'python3' is a 'command not found' error on Windows but 'py' works on Windows only

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ install_requires =
 # TODO pick the correct version.
 [options.extras_require]
 dev =
-    black>=19.10b0
+    black==19.10b0
     pytest>=4.0.0
     Sphinx>=3.0.3
     sphinx-markdown-builder>=0.5.4

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -88,3 +88,33 @@ class TestTypes(PandasTestCase):
             )
         except TypeError:
             self.fail("Failed although input type is correct.")
+
+    def test_inputseries_correct_type_first_value_is_nan_TextSeries(self):
+        @_types.InputSeries(_types.TextSeries)
+        def f(s):
+            pass
+
+        try:
+            f(pd.Series([np.nan, pd.NA, "I'm a TextSeries"]))
+        except TypeError:
+            self.fail("Failed although input type is correct.")
+
+    def test_inputseries_correct_type_first_value_is_nan_TokenSeries(self):
+        @_types.InputSeries(_types.TokenSeries)
+        def f(s):
+            pass
+
+        try:
+            f(pd.Series([np.nan, pd.NA, ["Token", "Series"]]))
+        except TypeError:
+            self.fail("Failed although input type is correct.")
+
+    def test_inputseries_correct_type_first_value_is_nan_VectorSeries(self):
+        @_types.InputSeries(_types.VectorSeries)
+        def f(s):
+            pass
+
+        try:
+            f(pd.Series([np.nan, pd.NA, [0, 1, 2]]))
+        except TypeError:
+            self.fail("Failed although input type is correct.")

--- a/texthero/_types.py
+++ b/texthero/_types.py
@@ -120,7 +120,11 @@ class TextSeries(HeroSeries):
             " See help(hero.HeroSeries) for more information."
         )
 
-        if not isinstance(s.iloc[0], str) or s.index.nlevels != 1:
+        try:
+            first_non_nan_value = s.loc[s.first_valid_index()]
+            if not isinstance(first_non_nan_value, str) or s.index.nlevels != 1:
+                raise TypeError(error_string)
+        except KeyError:  # Only NaNs in Series -> same warning applies
             raise TypeError(error_string)
 
 
@@ -146,7 +150,11 @@ class TokenSeries(HeroSeries):
                 cell, (list, tuple)
             )
 
-        if not is_list_of_strings(s.iloc[0]) or s.index.nlevels != 1:
+        try:
+            first_non_nan_value = s.loc[s.first_valid_index()]
+            if not is_list_of_strings(first_non_nan_value) or s.index.nlevels != 1:
+                raise TypeError(error_string)
+        except KeyError:  # Only NaNs in Series -> same warning applies
             raise TypeError(error_string)
 
 
@@ -179,7 +187,11 @@ class VectorSeries(HeroSeries):
         def is_list_of_numbers(cell):
             return all(is_numeric(x) for x in cell) and isinstance(cell, (list, tuple))
 
-        if not is_list_of_numbers(s.iloc[0]) or s.index.nlevels != 1:
+        try:
+            first_non_nan_value = s.loc[s.first_valid_index()]
+            if not is_list_of_numbers(first_non_nan_value) or s.index.nlevels != 1:
+                raise TypeError(error_string)
+        except KeyError:  # Only NaNs in Series -> same warning applies
             raise TypeError(error_string)
 
 


### PR DESCRIPTION
Currently, when using our `InputSeries` decorator, it always throws an error if the first Series value is NaN. This of course makes no sense for users.

Example:
```python
>>> import pandas as pd
>>> import texthero as hero
>>> s = pd.Series([pd.NA, "test"])
>>> hero.clean(s)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/henri/Prog/SummerOfCode/texthero/texthero/texthero/_types.py", line 233, in wrapper
    allowed_hero_series_type.check_series(s)
  File "/home/henri/Prog/SummerOfCode/texthero/texthero/texthero/_types.py", line 124, in check_series
    raise TypeError(error_string)
TypeError: The input Series should consist only of strings in every cell. See help(hero.HeroSeries) for more information.
```

We fix this by finding the first non-NaN value now and checking this.