### PR TITLE
Add infer test cases for test indexes

### DIFF
--- a/texthero/_types.py
+++ b/texthero/_types.py
@@ -226,6 +226,8 @@ def InputSeries(allowed_hero_series_type):
     """
 
     def decorator(func):
+        func.allowed_hero_series_type = allowed_hero_series_type
+
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
             s = args[0]  # The first input argument will be checked.


### PR DESCRIPTION
This PR add codes to generate test cases for each function according their input HeroSeries. Only functions with one HeroSeries input will be generated with test case. Exceptions can be manually added, for example,

```
test_case_exceptions = {}
for case in (
    test_cases_nlp
    + test_cases_preprocessing
    + test_cases_representation
    + test_cases_visualization
):
    test_case_exceptions[case[0]] = case
```
Then functions within `test_case_exceptions` will not be given a generated test case.
To omit some functions for testing, put them under `func_white_list`,
```
func_white_list = set(
    [s for s in inspect.getmembers(visualization, inspect.isfunction)]
)
```
