### PR TITLE
Move stem from preprocessing to nlp

### DIFF
--- a/tests/test_indexes.py
+++ b/tests/test_indexes.py
@@ -26,6 +26,7 @@ s_numeric_lists = pd.Series([[5.0, 5.0], [6.0, 6.0]], index=[5, 6])
 test_cases_nlp = [
     ["named_entities", nlp.named_entities, (s_text,)],
     ["noun_chunks", nlp.noun_chunks, (s_text,)],
+    ["stem", nlp.stem, (s_text,)],
 ]
 
 test_cases_preprocessing = [
@@ -39,7 +40,6 @@ test_cases_preprocessing = [
     ["remove_whitespace", preprocessing.remove_whitespace, (s_text,)],
     ["replace_stopwords", preprocessing.replace_stopwords, (s_text, "")],
     ["remove_stopwords", preprocessing.remove_stopwords, (s_text,)],
-    ["stem", preprocessing.stem, (s_text,)],
     ["clean", preprocessing.clean, (s_text,)],
     ["remove_round_brackets", preprocessing.remove_round_brackets, (s_text,)],
     ["remove_curly_brackets", preprocessing.remove_curly_brackets, (s_text,)],

--- a/texthero/nlp.py
+++ b/texthero/nlp.py
@@ -4,6 +4,7 @@ The texthero.nlp module supports common NLP tasks such as named_entities, noun_c
 
 import spacy
 import pandas as pd
+from nltk.stem import PorterStemmer, SnowballStemmer
 
 from texthero._types import TextSeries, InputSeries
 
@@ -215,3 +216,59 @@ def pos_tag(s: TextSeries) -> pd.Series:
         )
 
     return pd.Series(pos_tags, index=s.index)
+
+
+@InputSeries(TextSeries)
+def stem(s: TextSeries, stem="snowball", language="english") -> TextSeries:
+    r"""
+    Stem series using either `porter` or `snowball` NLTK stemmers.
+
+    The act of stemming means removing the end of a words with an heuristic
+    process.
+    It's useful in context where the meaning of the word is important rather
+    than his derivation. Stemming is very efficient and adapt in case the given
+    dataset is large.
+
+    Make use of two NLTK stemming algorithms known as
+    :class:`nltk.stem.SnowballStemmer` and :class:`nltk.stem.PorterStemmer`.
+    SnowballStemmer should be used when the Pandas Series contains non-English
+    text has it has multilanguage support.
+
+
+    Parameters
+    ----------
+    s : :class:`texthero._types.TextSeries`
+
+    stem : str, optional, default="snowball"
+        Stemming algorithm. It can be either 'snowball' or 'porter'
+
+    language : str, optional, default="english"
+        Supported languages: `danish`, `dutch`, `english`, `finnish`,
+        `french`, `german` , `hungarian`, `italian`, `norwegian`,
+        `portuguese`, `romanian`, `russian`, `spanish` and `swedish`.
+
+    Notes
+    -----
+    By default NLTK stemming algorithms lowercase all text.
+
+    Examples
+    --------
+    >>> import texthero as hero
+    >>> import pandas as pd
+    >>> s = pd.Series("I used to go \t\n running.")
+    >>> hero.stem(s)
+    0    i use to go running.
+    dtype: object
+    """
+
+    if stem == "porter":
+        stemmer = PorterStemmer()
+    elif stem == "snowball":
+        stemmer = SnowballStemmer(language)
+    else:
+        raise ValueError("stem argument must be either 'porter' of 'stemmer'")
+
+    def _stem(text):
+        return " ".join([stemmer.stem(word) for word in text])
+
+    return s.str.split().apply(_stem)

--- a/texthero/preprocessing.py
+++ b/texthero/preprocessing.py
@@ -373,62 +373,6 @@ def remove_stopwords(
     return replace_stopwords(s, symbol="", stopwords=stopwords)
 
 
-@InputSeries(TextSeries)
-def stem(s: TextSeries, stem="snowball", language="english") -> TextSeries:
-    r"""
-    Stem series using either `porter` or `snowball` NLTK stemmers.
-
-    The act of stemming means removing the end of a words with an heuristic
-    process.
-    It's useful in context where the meaning of the word is important rather
-    than his derivation. Stemming is very efficient and adapt in case the given
-    dataset is large.
-
-    Make use of two NLTK stemming algorithms known as
-    :class:`nltk.stem.SnowballStemmer` and :class:`nltk.stem.PorterStemmer`.
-    SnowballStemmer should be used when the Pandas Series contains non-English
-    text has it has multilanguage support.
-
-
-    Parameters
-    ----------
-    s : :class:`texthero._types.TextSeries`
-
-    stem : str, optional, default="snowball"
-        Stemming algorithm. It can be either 'snowball' or 'porter'
-
-    language : str, optional, default="english"
-        Supported languages: `danish`, `dutch`, `english`, `finnish`,
-        `french`, `german` , `hungarian`, `italian`, `norwegian`,
-        `portuguese`, `romanian`, `russian`, `spanish` and `swedish`.
-
-    Notes
-    -----
-    By default NLTK stemming algorithms lowercase all text.
-
-    Examples
-    --------
-    >>> import texthero as hero
-    >>> import pandas as pd
-    >>> s = pd.Series("I used to go \t\n running.")
-    >>> hero.stem(s)
-    0    i use to go running.
-    dtype: object
-    """
-
-    if stem == "porter":
-        stemmer = PorterStemmer()
-    elif stem == "snowball":
-        stemmer = SnowballStemmer(language)
-    else:
-        raise ValueError("stem argument must be either 'porter' of 'stemmer'")
-
-    def _stem(text):
-        return " ".join([stemmer.stem(word) for word in text])
-
-    return s.str.split().apply(_stem)
-
-
 def get_default_pipeline() -> List[Callable[[pd.Series], pd.Series]]:
     """
     Return a list contaning all the methods used in the default cleaning

--- a/texthero/preprocessing.py
+++ b/texthero/preprocessing.py
@@ -11,7 +11,6 @@ import unicodedata
 import numpy as np
 import pandas as pd
 import unidecode
-from nltk.stem import PorterStemmer, SnowballStemmer
 
 from texthero import stopwords as _stopwords
 from texthero._types import TokenSeries, TextSeries, InputSeries


### PR DESCRIPTION
We believe the stem function belongs to the NLP module and not the preprocessing module (together with lemmatization that will be implemented in #173 ). Of course it _can_ make sense to use it in preprocessing (and we should explain that in the NLP tutorial in #176 , but in our opinion it's more "Natural Language Processing" than "Preprocessing" so it should be moved. 

Of course, no code is changed in this PR, only moved.