### PR TITLE
Set pandas dev dependency to >=1.1.0. Closes #187

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -50,3 +50,4 @@ dev =
     parameterized>=0.7.4
     coverage
     pre-commit
+    pandas>=1.1.0


### PR DESCRIPTION
As described in #187 , we need this so all developers can run the tests.