### PR TITLE
Optional string in fillna

### DIFF
--- a/texthero/preprocessing.py
+++ b/texthero/preprocessing.py
@@ -24,7 +24,7 @@ warnings.filterwarnings(action="ignore", category=UserWarning, module="gensim")
 
 
 @InputSeries(TextSeries)
-def fillna(s: TextSeries, replace_string = "") -> TextSeries:
+def fillna(s: TextSeries, replace_string="") -> TextSeries:
     """
     Replaces not assigned values with empty or given string.
 

--- a/texthero/preprocessing.py
+++ b/texthero/preprocessing.py
@@ -24,24 +24,31 @@ warnings.filterwarnings(action="ignore", category=UserWarning, module="gensim")
 
 
 @InputSeries(TextSeries)
-def fillna(s: TextSeries) -> TextSeries:
+def fillna(s: TextSeries, replace_string = "") -> TextSeries:
     """
-    Replaces not assigned values with empty string.
-
+    Replaces not assigned values with empty or given string.
 
     Examples
     --------
     >>> import texthero as hero
     >>> import pandas as pd
+    >>> import numpy as np
     >>> s = pd.Series(["I'm", np.NaN, pd.NA, "You're"])
     >>> hero.fillna(s)
     0       I'm
-    1          
-    2          
+    1
+    2
+    3    You're
+    dtype: object
+    >>> hero.fillna(s, "Missing")
+    0       I'm
+    1   Missing
+    2   Missing
     3    You're
     dtype: object
     """
-    return s.fillna("").astype("str")
+
+    return s.fillna(replace_string).astype("str")
 
 
 @InputSeries(TextSeries)

--- a/texthero/preprocessing.py
+++ b/texthero/preprocessing.py
@@ -36,15 +36,15 @@ def fillna(s: TextSeries, replace_string = "") -> TextSeries:
     >>> s = pd.Series(["I'm", np.NaN, pd.NA, "You're"])
     >>> hero.fillna(s)
     0       I'm
-    1           
-    2
+    1          
+    2          
     3    You're
     dtype: object
     >>> hero.fillna(s, "Missing")
-    0       I'm
-    1   Missing
-    2   Missing
-    3    You're
+    0        I'm
+    1    Missing
+    2    Missing
+    3     You're
     dtype: object
     """
 

--- a/texthero/preprocessing.py
+++ b/texthero/preprocessing.py
@@ -36,7 +36,7 @@ def fillna(s: TextSeries, replace_string = "") -> TextSeries:
     >>> s = pd.Series(["I'm", np.NaN, pd.NA, "You're"])
     >>> hero.fillna(s)
     0       I'm
-    1
+    1           
     2
     3    You're
     dtype: object


### PR DESCRIPTION
Hey, i added an optional argument in fillna, for those, like me, who need to fill missing values with an custom string.

Example:

```python
>>> hero.fillna(s, "Custom String!!")
0                I'm
1    Custom String!!
2    Custom String!!
3             You're
dtype: object
```