### PR TITLE
Add HTML tags removing to default preprocessing pipeline

### DIFF
--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -114,6 +114,13 @@ class TestPreprocessing(PandasTestCase):
         pipeline = [preprocessing.lowercase, preprocessing.remove_stopwords]
         self.assertEqual(preprocessing.clean(s, pipeline=pipeline), s_true)
 
+    def test_pipeline_default(self):
+        s = pd.Series(
+            "Amazon! < br />< br /> If I was going to order any soft drink online, it would be Diet Coke with Lime"
+        )
+        s_true = pd.Series("amazon going order soft drink online would diet coke lime")
+        self.assertEqual(preprocessing.clean(s), s_true)
+
     """
     Test stopwords.
     """
@@ -151,8 +158,8 @@ class TestPreprocessing(PandasTestCase):
     """
 
     def test_remove_html_tags(self):
-        s = pd.Series("<html>remove <br>html</br> tags<html> &nbsp;")
-        s_true = pd.Series("remove html tags ")
+        s = pd.Series("<html>remove <br>html</br> tags<html> &nbsp; < br />< br />")
+        s_true = pd.Series("remove html tags  ")
         self.assertEqual(preprocessing.remove_html_tags(s), s_true)
 
     """

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -116,9 +116,19 @@ class TestPreprocessing(PandasTestCase):
 
     def test_pipeline_default(self):
         s = pd.Series(
-            "Amazon! < br />< br /> If I was going to order any soft drink online, it would be Diet Coke with Lime"
+            [
+                "Amazon! < br />< br /> If I was going to order any soft drink online, it would be Diet Coke with Lime",
+                pd.NA,
+                "-1234. Mère, Françoise, noël",
+            ]
         )
-        s_true = pd.Series("amazon going order soft drink online would diet coke lime")
+        s_true = pd.Series(
+            [
+                "amazon going order soft drink online would diet coke lime",
+                "",
+                "mere francoise noel",
+            ]
+        )
         self.assertEqual(preprocessing.clean(s), s_true)
 
     """

--- a/texthero/preprocessing.py
+++ b/texthero/preprocessing.py
@@ -388,10 +388,11 @@ def get_default_pipeline() -> List[Callable[[pd.Series], pd.Series]]:
      1. :meth:`texthero.preprocessing.fillna`
      2. :meth:`texthero.preprocessing.lowercase`
      3. :meth:`texthero.preprocessing.remove_digits`
-     4. :meth:`texthero.preprocessing.remove_punctuation`
-     5. :meth:`texthero.preprocessing.remove_diacritics`
-     6. :meth:`texthero.preprocessing.remove_stopwords`
-     7. :meth:`texthero.preprocessing.remove_whitespace`
+     4. :meth:`texthero.preprocessing.remove_html_tags`
+     5. :meth:`texthero.preprocessing.remove_punctuation`
+     6. :meth:`texthero.preprocessing.remove_diacritics`
+     7. :meth:`texthero.preprocessing.remove_stopwords`
+     8. :meth:`texthero.preprocessing.remove_whitespace`
     """
     return [
         fillna,

--- a/texthero/preprocessing.py
+++ b/texthero/preprocessing.py
@@ -397,6 +397,7 @@ def get_default_pipeline() -> List[Callable[[pd.Series], pd.Series]]:
         fillna,
         lowercase,
         remove_digits,
+        remove_html_tags,
         remove_punctuation,
         remove_diacritics,
         remove_stopwords,

--- a/texthero/preprocessing.py
+++ b/texthero/preprocessing.py
@@ -415,10 +415,11 @@ def clean(s: TextSeries, pipeline=None) -> TextSeries:
      1. :meth:`texthero.preprocessing.fillna`
      2. :meth:`texthero.preprocessing.lowercase`
      3. :meth:`texthero.preprocessing.remove_digits`
-     4. :meth:`texthero.preprocessing.remove_punctuation`
-     5. :meth:`texthero.preprocessing.remove_diacritics`
-     6. :meth:`texthero.preprocessing.remove_stopwords`
-     7. :meth:`texthero.preprocessing.remove_whitespace`
+     4. :meth:`texthero.preprocessing.remove_html_tags`
+     5. :meth:`texthero.preprocessing.remove_punctuation`
+     6. :meth:`texthero.preprocessing.remove_diacritics`
+     7. :meth:`texthero.preprocessing.remove_stopwords`
+     8. :meth:`texthero.preprocessing.remove_whitespace`
 
     Parameters
     ----------


### PR DESCRIPTION
Since it is a common preprocessing step, having `remove_html_tags` on default preprocessing pipeline is a good out-of-the-box behavior. Anyways, the user can always define the custom pipeline. Example:

```python
>>> s = pd.Series("Amazon! < br />< br /> If I was going to order any soft drink online, it would be Diet Coke with Lime")
>>> hero.clean(s)
0    amazon going order soft drink online would die...
dtype: object
```

Fix #191