### PR TITLE
Lazy load stopwords module to prevent downloading when it's not needed

### DIFF
--- a/texthero/nlp.py
+++ b/texthero/nlp.py
@@ -4,9 +4,17 @@ The texthero.nlp module supports common NLP tasks such as named_entities, noun_c
 
 import spacy
 import pandas as pd
-import en_core_web_sm
 from nltk.stem import PorterStemmer, SnowballStemmer
 from texthero._types import TextSeries, InputSeries
+
+try:
+    # If not present, download 'en_core_web_sm'
+    import en_core_web_sm
+except ModuleNotFoundError:
+    from spacy.cli.download import download as spacy_download
+
+    spacy_download("en_core_web_sm")
+    import en_core_web_sm
 
 
 @InputSeries(TextSeries)

--- a/texthero/preprocessing.py
+++ b/texthero/preprocessing.py
@@ -12,7 +12,6 @@ import numpy as np
 import pandas as pd
 import unidecode
 
-from texthero import stopwords as _stopwords
 from texthero._types import TokenSeries, TextSeries, InputSeries
 
 from typing import List, Callable, Union
@@ -329,6 +328,7 @@ def replace_stopwords(
     """
 
     if stopwords is None:
+        from texthero import stopwords as _stopwords
         stopwords = _stopwords.DEFAULT
     return s.apply(_replace_stopwords, args=(stopwords, symbol))
 

--- a/texthero/preprocessing.py
+++ b/texthero/preprocessing.py
@@ -329,6 +329,7 @@ def replace_stopwords(
 
     if stopwords is None:
         from texthero import stopwords as _stopwords
+
         stopwords = _stopwords.DEFAULT
     return s.apply(_replace_stopwords, args=(stopwords, symbol))
 

--- a/texthero/stopwords.py
+++ b/texthero/stopwords.py
@@ -8,15 +8,6 @@ except LookupError:
     nltk.download("stopwords")
 
 from nltk.corpus import stopwords as nltk_en_stopwords
-
-try:
-    # If not present, download 'en_core_web_sm'
-    spacy_model = spacy.load("en_core_web_sm")
-except OSError:
-    from spacy.cli.download import download as spacy_download
-
-    spacy_download("en_core_web_sm")
-
 from spacy.lang.en import stop_words as spacy_en_stopwords
 
 DEFAULT = set(nltk_en_stopwords.words("english"))


### PR DESCRIPTION
Import `stopwords` module inside `replace_stopwords` function, so the data is downloaded only when it's necessary.

Fixes #193