### PR TITLE
Remove unused dependency unidecode

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,6 @@ install_requires =
     plotly>=4.2.0
     pandas>=1.0.2
     wordcloud>=1.5.0
-    unidecode>=1.1.1
     gensim>=3.6.0
     matplotlib>=3.1.0
 # TODO pick the correct version.

--- a/texthero/preprocessing.py
+++ b/texthero/preprocessing.py
@@ -10,7 +10,6 @@ import unicodedata
 
 import numpy as np
 import pandas as pd
-import unidecode
 
 from texthero._types import TokenSeries, TextSeries, InputSeries
 


### PR DESCRIPTION
Unidecode is no longer being used in this project. Further, it comes under a GPL license, which may make using TextHero problematic in some projects.